### PR TITLE
Add download cslc convenience function

### DIFF
--- a/src/opera_utils/__init__.py
+++ b/src/opera_utils/__init__.py
@@ -4,15 +4,14 @@
 from __future__ import annotations
 
 from ._dates import *
+from ._gslc import *
+from ._helpers import *
+from ._utils import *
 from ._version import version as __version__
-from .bursts import *
 from .burst_frame_db import *
+from .bursts import *
 from .constants import *
 from .datasets import *
 from .missing_data import *
-from ._utils import *
-from ._gslc import *
-from ._helpers import *
-
 
 __all__ = ["__version__"]

--- a/src/opera_utils/_gslc.py
+++ b/src/opera_utils/_gslc.py
@@ -7,6 +7,11 @@ import h5py
 
 from ._types import Filename
 
+__all__ = [
+    "get_zero_doppler_time",
+    "get_radar_wavelength",
+]
+
 
 def get_zero_doppler_time(
     filename: Filename, type_: str = "start"
@@ -80,7 +85,7 @@ def get_radar_wavelength(filename: Filename):
     Returns
     -------
     wavelength : float
-        Radar wavelength.
+        Radar wavelength in meters.
     """
     dset = "/metadata/processing_information/input_burst_metadata/wavelength"
     value = _get_dset_and_attrs(filename, dset)[0]

--- a/src/opera_utils/_types.py
+++ b/src/opera_utils/_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import sys
 from os import PathLike
-from typing import TYPE_CHECKING, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, NamedTuple, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
@@ -23,11 +23,33 @@ PathOrStr = Union[str, PathLikeStr]
 Filename = PathOrStr  # May add a deprecation notice for `Filename`
 PathLikeT = TypeVar("PathLikeT", bound=PathLikeStr)
 
-# left, bottom, right, top
-Bbox = Tuple[float, float, float, float]
-
 # Used for callable types
 T = TypeVar("T")
 P = ParamSpec("P")
 
 DateOrDatetime = Union[datetime.datetime, datetime.date]
+
+
+class Bbox(NamedTuple):
+    """Bounding box named tuple, defining extent in cartesian coordinates.
+
+    Usage:
+
+        Bbox(left, bottom, right, top)
+
+    Attributes
+    ----------
+    left : float
+        Left coordinate (xmin)
+    bottom : float
+        Bottom coordinate (ymin)
+    right : float
+        Right coordinate (xmax)
+    top : float
+        Top coordinate (ymax)
+    """
+
+    left: float
+    bottom: float
+    right: float
+    top: float

--- a/src/opera_utils/_utils.py
+++ b/src/opera_utils/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import tempfile
@@ -159,7 +160,7 @@ def scratch_directory(
         shutil.rmtree(scratchdir)
 
 
-def get_snwe(epsg: int, bounds: Bbox) -> Bbox:
+def get_snwe(epsg: int, bounds: Bbox) -> tuple[float, float, float, float]:
     """Convert bounds from (west, south, east, north) (WSEN) to SNWE in lat/lon.
 
     This box format is used by the `RAiDER` library for its area of interest tracking:
@@ -252,3 +253,45 @@ def transform_xy_to_latlon(
         longitude = x.copy()
 
     return latitude, longitude
+
+
+# https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging
+class LoggingContext:
+    """A logging context manager.
+
+    This class is used to temporarily add a logging handler to a logger. It can be used
+    as follows:
+
+    >>> logger = logging.getLogger(__name__)
+    >>> with LoggingContext(logger, level=logging.DEBUG, handler=logging.StreamHandler()):
+    ...     logger.debug("This is a debug message")
+
+    >>> logger.debug("This is a debug message")  # won't be printed
+    """
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        level: int | str | None = None,
+        handler: logging.Handler | None = None,
+        close: bool = True,
+    ):
+        self.logger = logger
+        self.level = level
+        self.handler = handler
+        self.close = close
+
+    def __enter__(self):
+        if self.level is not None:
+            self.old_level = self.logger.level
+            self.logger.setLevel(self.level)
+        if self.handler:
+            self.logger.addHandler(self.handler)
+
+    def __exit__(self, et, ev, tb):
+        if self.level is not None:
+            self.logger.setLevel(self.old_level)
+        if self.handler:
+            self.logger.removeHandler(self.handler)
+        if self.handler and self.close:
+            self.handler.close()

--- a/src/opera_utils/burst_frame_db.py
+++ b/src/opera_utils/burst_frame_db.py
@@ -143,7 +143,7 @@ def get_frame_bbox(
         float(frame_dict["xmax"]),
         float(frame_dict["ymax"]),
     )
-    return epsg, bounds
+    return epsg, Bbox(*bounds)
 
 
 def get_burst_ids_for_frame(

--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -156,9 +156,7 @@ def _download_for_burst_ids(
     list[Path]
         Locations to saved raster files.
     """
-    # cm = LoggingContext if verbose else _DummyContext
-    cm = LoggingContext
-    # cm = _DummyContext
+    cm = LoggingContext if verbose else _DummyContext
     with cm(logger, level=logging.INFO, handler=logging.StreamHandler()):
         # Make a tuple so it can be hashed
         logger.info(

--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import netrc
+import warnings
+from enum import Enum
+from functools import cache
+from pathlib import Path
+from typing import Literal, Sequence
+
+try:
+    import asf_search as asf
+except ImportError:
+    warnings.warn("Can't import `asf_search`. Unable to search/download data. ")
+
+from opera_utils._types import PathOrStr
+
+__all__ = [
+    "download_cslc_static_layers",
+    "download_cslcs",
+]
+
+logger = logging.getLogger(__name__)
+
+
+class L2Product(str, Enum):
+    """OPERA Level 2 product types available on ASF."""
+
+    CSLC = "CSLC"
+    CSLC_STATIC = "CSLC-STATIC"
+    RTC = "RTC"
+    RTC_STATIC = "RTC-STATIC"
+
+
+# Type for ASF Search start/end times
+DatetimeInput = datetime.datetime | str | None
+
+
+def download_cslc_static_layers(
+    burst_ids: Sequence[str], output_dir: PathOrStr, max_jobs: int = 3
+) -> list[Path]:
+    """Download the static layers for a sequence of burst IDs.
+
+    Parameters
+    ----------
+    burst_ids : Sequence[str]
+        Sequence of OPERA Burst IDs (e.g. 'T123_012345_IW1')
+    output_dir : Path | str
+        Location to save output rasters to
+    max_jobs : int, optional
+        Number of parallel downloads to run, by default 3
+
+    Returns
+    -------
+    list[Path]
+        Locations to saved raster files.
+    """
+    return _download_for_burst_ids(
+        burst_ids=burst_ids,
+        output_dir=output_dir,
+        max_jobs=max_jobs,
+        product=L2Product.CSLC_STATIC,
+    )
+
+
+def download_cslcs(
+    burst_ids: Sequence[str],
+    output_dir: PathOrStr,
+    start: DatetimeInput = None,
+    end: DatetimeInput = None,
+    max_jobs: int = 3,
+) -> list[Path]:
+    """Download the static layers for a sequence of burst IDs.
+
+    Parameters
+    ----------
+    burst_ids : Sequence[str]
+        Sequence of OPERA Burst IDs (e.g. 'T123_012345_IW1')
+    output_dir : Path | str
+        Location to save output rasters to
+    start: datetime.datetime | str, optional
+        Start date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+    end: datetime.datetime | str, optional
+        end: End date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+    max_jobs : int, optional
+        Number of parallel downloads to run, by default 3
+
+    Returns
+    -------
+    list[Path]
+        Locations to saved raster files.
+    """
+    return _download_for_burst_ids(
+        burst_ids=burst_ids,
+        output_dir=output_dir,
+        max_jobs=max_jobs,
+        start=start,
+        end=end,
+        product=L2Product.CSLC,
+    )
+
+
+def _download_for_burst_ids(
+    burst_ids: Sequence[str],
+    output_dir: PathOrStr,
+    product: L2Product,
+    max_jobs: int = 3,
+    start: DatetimeInput = None,
+    end: DatetimeInput = None,
+) -> list[Path]:
+    """Download files for one product type fo static layers for a sequence of burst IDs.
+
+    Parameters
+    ----------
+    burst_ids : Sequence[str]
+        Sequence of OPERA Burst IDs (e.g. 'T123_012345_IW1')
+    output_dir : Path
+        Location to save output rasters to
+    product : L2Product
+        Type of OPERA product to download.
+    max_jobs : int, optional
+        Number of parallel downloads to run, by default 3
+    start: datetime.datetime | str, optional
+        Start date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+    end: datetime.datetime | str, optional
+        end: End date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+
+    Returns
+    -------
+    list[Path]
+        Locations to saved raster files.
+    """
+    # Make a tuple so it can be hashed
+    logger.debug(f"Searching {len(burst_ids)} for {product} from {start} to {end}")
+    results = _search(burst_ids=tuple(burst_ids), product=product, start=start, end=end)
+    logger.info(f"Found {len(results)} results")
+    session = _get_auth_session()
+    urls = _get_urls(results)
+    asf.download_urls(
+        urls=urls, path=str(output_dir), session=session, processes=max_jobs
+    )
+    return [Path(output_dir) / r.properties["fileName"] for r in results]
+
+
+@cache
+def _search(
+    burst_ids: Sequence[str],
+    product: L2Product,
+    start: DatetimeInput,
+    end: DatetimeInput,
+) -> asf.ASFSearchResults:
+    return asf.search(
+        operaBurstID=list(burst_ids),
+        processingLevel=product.value,
+        start=start,
+        end=end,
+    )
+
+
+def _get_urls(
+    results: asf.ASFSearchResults,
+    type_: Literal["https", "s3"] = "https",
+) -> list[str]:
+    if type_ == "https":
+        return [r.properties["url"] for r in results]
+    elif type_ == "s3":
+        # TODO: go through .umm, find s3 url
+        raise NotImplementedError()
+    else:
+        raise ValueError(f"type_ must be 'https' or 's3'. Got {type_}")
+    # r.umm
+    # 'RelatedUrls': [...
+    #     {'URL': 's3://asf-cumulus-prod-opera-products/OPERA_L2_CSLC
+    #    'Type': 'GET DATA VIA DIRECT ACCESS',
+    #    'Description': 'This link provides direct download access vi
+    #    'Format': 'HDF5'},
+
+
+def _get_auth_session() -> asf.ASFSession:
+    host = "urs.earthdata.nasa.gov"
+
+    auth = netrc.netrc().authenticators(host)
+    if auth is None:
+        raise ValueError(f"No .netrc entry found for {host}")
+    username, _, password = auth
+    return asf.ASFSession().auth_with_creds(username, password)


### PR DESCRIPTION
Example usage:

```python
import opera_utils.download

burst_ids = opera_utils.get_burst_ids_for_frame(11114)
opera_utils.download.download_cslcs(burst_ids[:2], output_dir='.', start='2023-12-01', end='2024-01-01', max_jobs=2, verbose=True)
```