### PR TITLE
Remove length check from `sort_files_by_date`

### DIFF
--- a/src/opera_utils/_dates.py
+++ b/src/opera_utils/_dates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import itertools
+import operator
 import re
 from collections import defaultdict
 from typing import Iterable, overload
@@ -223,20 +224,11 @@ def sort_files_by_date(
     dates : list[list[datetime.date,...]]
         Sorted list, where each entry has all the dates from the corresponding file.
     """
-
-    def sort_key(file_date_tuple):
-        # Key for sorting:
-        # To sort the files with the most dates first (the compressed SLCs which
-        # span a date range), sort the longer date lists first.
-        # Then, within each group of dates of the same length, use the date/dates
-        _, dates = file_date_tuple
-        try:
-            return (-len(dates), dates)
-        except TypeError:
-            return (-1, dates)
-
     file_date_tuples = [(f, get_dates(f, fmt=file_date_fmt)) for f in files]
-    file_dates = sorted([fd_tuple for fd_tuple in file_date_tuples], key=sort_key)
+    # Get the second item in the tuple for the key
+    file_dates = sorted(
+        [fd_tuple for fd_tuple in file_date_tuples], key=operator.itemgetter(1)
+    )
 
     # Unpack the sorted pairs with new sorted values
     file_list, dates = zip(*file_dates)  # type: ignore

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -180,32 +180,32 @@ def test_sort_files_by_date_interferograms():
     assert sorted_dates == sorted(dates)
 
 
-def test_sort_files_by_date_compressed_first():
-    # Check that compressed SLCs go first, then SLCs are sorted by date
+def test_sort_files_with_varying_date_lengths():
+    """Check we handle files with varying date lengths, looking at first date only."""
     unsorted_files = [
         "slc_20200101.tif",
         "slc_20210101.tif",
         "slc_20190101.tif",
         "compressed_20180101_20200101.tif",
-        "slc_20180101.tif",
-        "compressed_20200101_20210101.tif",
+        "slc_20180102.tif",
+        "compressed_20200102_20210101.tif",
     ]
     expected_dates = [
         [datetime.datetime(2018, 1, 1), datetime.datetime(2020, 1, 1)],
-        [datetime.datetime(2020, 1, 1), datetime.datetime(2021, 1, 1)],
-        [datetime.datetime(2018, 1, 1)],
+        [datetime.datetime(2018, 1, 2)],
         [datetime.datetime(2019, 1, 1)],
         [datetime.datetime(2020, 1, 1)],
+        [datetime.datetime(2020, 1, 2), datetime.datetime(2021, 1, 1)],
         [datetime.datetime(2021, 1, 1)],
     ]
 
     sorted_files, sorted_dates = _dates.sort_files_by_date(unsorted_files)
     assert sorted_files == [
         "compressed_20180101_20200101.tif",
-        "compressed_20200101_20210101.tif",
-        "slc_20180101.tif",
+        "slc_20180102.tif",
         "slc_20190101.tif",
         "slc_20200101.tif",
+        "compressed_20200102_20210101.tif",
         "slc_20210101.tif",
     ]
     assert sorted_dates == expected_dates


### PR DESCRIPTION
The original thinking for sticking multi-date files first in order to move compressed SLCs before real SLCs is not sound. The compressed SLCs still have dates in them, but we can't mix 3-date SLCs and 2-date ones.

There is no reason to keep the length check.