### PR TITLE
Return degrees for `get_lonlat_grid`, not radians

### DIFF
--- a/src/opera_utils/_gslc.py
+++ b/src/opera_utils/_gslc.py
@@ -221,7 +221,7 @@ def get_lonlat_grid(
     yy = Y.flatten()
     crs = CRS.from_epsg(projection)
     transformer = Transformer.from_crs(crs, CRS.from_epsg(4326), always_xy=True)
-    lon, lat = transformer.transform(xx=xx, yy=yy, radians=True)
+    lon, lat = transformer.transform(xx=xx, yy=yy, radians=False)
     lon = lon.reshape(X.shape)
     lat = lat.reshape(Y.shape)
     return lon, lat

--- a/tests/test_gslc.py
+++ b/tests/test_gslc.py
@@ -123,10 +123,10 @@ def test_get_lonlat_grid():
     lons, lats = get_lonlat_grid(TEST_FILE)
     assert lons.shape == (46, 199)
     assert lons.dtype == np.float64
-    assert lons[0, 0] == -2.0990052428418124
+    assert lons[0, 0] == -120.2641415906683
     assert lats.shape == (46, 199)
     assert lats.dtype == np.float64
-    assert lats[0, 0] == 0.6928179204952867
+    assert lats[0, 0] == 39.69554281541014
     assert np.all(np.diff(lons) > 0)
     # Lats are in descending order
     assert np.all(np.diff(lats) < 0)


### PR DESCRIPTION
`radians=True` did not match the docstring