### PR TITLE
Add `missing-data` CLI tool for subsetting acquisitions

### DIFF
--- a/src/opera_utils/cli.py
+++ b/src/opera_utils/cli.py
@@ -85,13 +85,15 @@ def missing_data_options(
     from opera_utils import filter_by_burst_id, filter_by_date, get_missing_data_options
 
     def print_plain(options):
-        header = f"{'Option #':<8} {'# of Dates':<12} {'# of Burst IDs':<14}"
-        header += f" {'Total Bursts':<14} {'Excluded Bursts':<14} "
+        header = f"|{'Option':<6}| {'# Dates':<10}| {'# Burst IDs':<14}|"
+        header += f" {'Selected Bursts':<15}| {'Excluded Bursts':<15}| "
         print(header)
         print("-" * len(header))
 
         for idx, option in enumerate(options, start=1):
-            row = f"{idx:<8} {option.num_dates:<12} {option.num_burst_ids:<14} {option.total_num_bursts:<14}"
+            excluded = option.num_candidate_bursts - option.total_num_bursts
+            row = f"|{idx:<6}| {option.num_dates:<10}| {option.num_burst_ids:<14}|"
+            row += f" {option.total_num_bursts:<15}| {excluded:<15}|"
             print(row)
         print()
 

--- a/src/opera_utils/cli.py
+++ b/src/opera_utils/cli.py
@@ -15,7 +15,7 @@ from .burst_frame_db import get_frame_bbox
 @click.option("--debug", is_flag=True, default=False)
 @click.pass_context
 def cli_app(ctx, debug):
-    """Orca command-line interface."""
+    """opera-utils command-line interface."""
     level = logging.DEBUG if debug else logging.INFO
     handler = logging.StreamHandler()
     logging.basicConfig(level=level, handlers=[handler])
@@ -53,3 +53,94 @@ def frame_bbox(frame_id, latlon: bool, bounds_only: bool):
     else:
         obj = dict(epsg=epsg, bbox=bounds)
         click.echo(json.dumps(obj))
+
+
+@cli_app.command()
+@click.argument("namelist", type=click.File("r"))
+@click.option(
+    "--write-options/--no-write-options",
+    default=True,
+    help="Write out each option to a text file.",
+)
+@click.option(
+    "--output-prefix",
+    type=str,
+    default="option_",
+    help="Prefix for output filenames.",
+    show_default=True,
+)
+@click.option(
+    "--verbose", is_flag=True, help="Print full list of burst IDs for each option"
+)
+def missing_data_options(
+    namelist, write_options: bool, output_prefix: str, verbose: bool
+):
+    """Get a list of options for how to handle missing data.
+
+    Prints a table of options to stdout, and writes the subset
+    of files to disk for each option with names like
+
+    option_1_bursts_1234_burst_ids_27_dates_10.txt
+    """
+    from opera_utils import filter_by_burst_id, filter_by_date, get_missing_data_options
+
+    def print_plain(options):
+        header = f"{'Option #':<8} {'# of Dates':<12} {'# of Burst IDs':<14}"
+        header += f" {'Total Bursts':<14} {'Excluded Bursts':<14} "
+        print(header)
+        print("-" * len(header))
+
+        for idx, option in enumerate(options, start=1):
+            row = f"{idx:<8} {option.num_dates:<12} {option.num_burst_ids:<14} {option.total_num_bursts:<14}"
+            print(row)
+        print()
+
+    def print_with_rich(options):
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console()
+        table = Table(show_header=True, header_style="bold magenta")
+        table.add_column("Option", style="dim", width=6)
+        table.add_column("# Dates", style="dim", width=10)
+        table.add_column("# Burst IDs", style="dim", width=14)
+        table.add_column("Selected Bursts", style="dim", width=15)
+        table.add_column("Excluded Bursts", style="dim", width=15)
+
+        for idx, option in enumerate(options, start=1):
+            table.add_row(
+                str(idx),
+                str(option.num_dates),
+                str(option.num_burst_ids),
+                str(option.total_num_bursts),
+                str(option.num_candidate_bursts - option.total_num_bursts),
+            )
+        console.print(table)
+
+    file_list = [f.strip() for f in namelist.read().splitlines()]
+    options = get_missing_data_options(file_list)
+
+    try:
+        print_with_rich(options)
+    except ImportError:
+        print_plain(options)
+    if not write_options:
+        return
+
+    # Now filter the files by the burst ids in each, and output to separate
+    for idx, option in enumerate(options, start=1):
+        cur_burst_ids = option.burst_ids
+        # The selected files are those which match the selected date + burst IDs
+        valid_date_files = filter_by_date(file_list, option.dates)
+        valid_files = filter_by_burst_id(valid_date_files, cur_burst_ids)
+
+        cur_output = (
+            f"{output_prefix}{idx}"
+            f"_bursts_{option.total_num_bursts}"
+            f"_burst_ids_{len(cur_burst_ids)}"
+            f"_dates_{option.num_dates}.txt"
+        )
+        click.echo(f"Writing {len(valid_files)} files to {cur_output}")
+        with open(cur_output, "w") as f:
+            f.write("\n".join(valid_files))
+            f.write("\n")

--- a/src/opera_utils/missing_data.py
+++ b/src/opera_utils/missing_data.py
@@ -184,15 +184,15 @@ def _burst_id_mapping_from_tuples(
 def _burst_id_mapping_from_files(
     slc_files: Iterable[Filename],
 ) -> dict[str, list[datetime]]:
-    """Create a {burst_id -> [datetime,...]} mapping from filenames."""
+    """Create a {burst_id -> [datetime,...]} mapping from filenames.
+
+    Assumes the first datetime in the filename is the relevant one.
+    """
     # Don't exhaust the iterator for multiple groupings
     slc_file_list = list(map(str, slc_files))
 
     # Group the possible SLC files by their datetime and by their Burst ID
     burst_id_to_files = group_by_burst(slc_file_list)
-
-    date_tuples = [get_dates(f) for f in slc_file_list]
-    assert all(len(tup) == 1 for tup in date_tuples)
 
     return {
         burst_id: [get_dates(f)[0] for f in file_list]


### PR DESCRIPTION
Example: for a directory with OPERA CSLCs in `slcs/`, you can check for consistent subsets like this:

```
$ ls slcs/*h5 | opera-utils missing-data-options -
```

the `-` means "read from stdin"

```
$ ls slcs/*h5 | opera-utils missing-data-options -
|Option| # Dates   | # Burst IDs   | Selected Bursts| Excluded Bursts|
-----------------------------------------------------------------------
|1     | 15        | 2             | 30             | 24             |
|2     | 27        | 1             | 27             | 27             |
|3     | 11        | 2             | 22             | 32             |
|4     | 12        | 1             | 12             | 42             |

Writing 30 files to option_1_bursts_30_burst_ids_2_dates_15.txt
Writing 27 files to option_2_bursts_27_burst_ids_1_dates_27.txt
Writing 22 files to option_3_bursts_22_burst_ids_2_dates_11.txt
Writing 12 files to option_4_bursts_12_burst_ids_1_dates_12.txt
```

The options are saved to a file by default, so you can run `dolphin config --slc-files @option_1_bursts_30_burst_ids_2_dates_15.txt ...`

if you have rich installed, it's prettier:

```
┏━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Option ┃ # Dates    ┃ # Burst IDs    ┃ Selected Bursts ┃ Excluded Bursts ┃
┡━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ 1      │ 15         │ 2              │ 30              │ 24              │
│ 2      │ 27         │ 1              │ 27              │ 27              │
│ 3      │ 11         │ 2              │ 22              │ 32              │
│ 4      │ 12         │ 1              │ 12              │ 42              │
└────────┴────────────┴────────────────┴─────────────────┴─────────────────┘
```