### PR TITLE
Add a `search_cslcs` to check results/missing data before download

### DIFF
--- a/src/opera_utils/_utils.py
+++ b/src/opera_utils/_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 import tempfile
@@ -253,45 +252,3 @@ def transform_xy_to_latlon(
         longitude = x.copy()
 
     return latitude, longitude
-
-
-# https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging
-class LoggingContext:
-    """A logging context manager.
-
-    This class is used to temporarily add a logging handler to a logger. It can be used
-    as follows:
-
-    >>> logger = logging.getLogger(__name__)
-    >>> with LoggingContext(logger, level=logging.DEBUG, handler=logging.StreamHandler()):
-    ...     logger.debug("This is a debug message")
-
-    >>> logger.debug("This is a debug message")  # won't be printed
-    """
-
-    def __init__(
-        self,
-        logger: logging.Logger,
-        level: int | str | None = None,
-        handler: logging.Handler | None = None,
-        close: bool = True,
-    ):
-        self.logger = logger
-        self.level = level
-        self.handler = handler
-        self.close = close
-
-    def __enter__(self):
-        if self.level is not None:
-            self.old_level = self.logger.level
-            self.logger.setLevel(self.level)
-        if self.handler:
-            self.logger.addHandler(self.handler)
-
-    def __exit__(self, et, ev, tb):
-        if self.level is not None:
-            self.logger.setLevel(self.old_level)
-        if self.handler:
-            self.logger.removeHandler(self.handler)
-        if self.handler and self.close:
-            self.handler.close()

--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -18,7 +18,8 @@ try:
 except ImportError:
     warnings.warn("Can't import `asf_search`. Unable to search/download data. ")
 
-from opera_utils._types import PathOrStr
+from ._types import PathOrStr
+from .missing_data import BurstSubsetOption, get_missing_data_options
 
 __all__ = [
     "download_cslc_static_layers",
@@ -84,7 +85,8 @@ def search_cslcs(
     burst_ids: Sequence[str] | None = None,
     max_results: int | None = None,
     verbose: bool = False,
-) -> ASFSearchResults:
+    check_missing_data: bool = False,
+) -> ASFSearchResults | tuple[ASFSearchResults, list[BurstSubsetOption]]:
     """Search for OPERA CSLC products on ASF.
 
     Parameters
@@ -105,6 +107,8 @@ def search_cslcs(
         Maximum number of results to return
     verbose : bool, optional
         Whether to print verbose output, by default False
+    check_missing_data : bool, optional
+        Whether to remove missing data options from the search results, by default False
 
     Returns
     -------
@@ -130,7 +134,12 @@ def search_cslcs(
         maxResults=max_results,
     )
     logger.info(f"Found {len(results)} results")
-    return results
+    if not check_missing_data:
+        return results
+    missing_data_options = get_missing_data_options(
+        slc_files=[r.properties["fileName"] for r in results]
+    )
+    return results, missing_data_options
 
 
 def download_cslcs(

--- a/src/opera_utils/missing_data.py
+++ b/src/opera_utils/missing_data.py
@@ -46,49 +46,6 @@ class BurstSubsetOption:
         return len(self.burst_ids)
 
 
-def get_burst_id_to_dates(
-    slc_files: Optional[Iterable[Filename]] = None,
-    burst_id_date_tuples: Optional[Iterable[tuple[str, datetime]]] = None,
-) -> dict[str, list[datetime]]:
-    """Get a mapping of burst ID to list of dates.
-
-    Assumes that the `slc_files` have only one datetime in the name, or
-    that the first datetime in the `burst_id_date_tuples` is the relevant
-    one (as is the case for OPERA CSLCs).
-
-
-    Parameters
-    ----------
-    slc_files : Optional[Iterable[Filename]]
-        List of OPERA CSLC filenames.
-    burst_id_date_tuples : Optional[Iterable[tuple[str, datetime]]]
-        Alternative input: list of all existing (burst_id, datetime) tuples.
-
-    Returns
-    -------
-    dict[str, list[datetime]]
-        Mapping of burst ID to list of dates.
-    """
-    if slc_files is not None:
-        return _burst_id_mapping_from_files(slc_files)
-    elif burst_id_date_tuples is not None:
-        return _burst_id_mapping_from_tuples(burst_id_date_tuples)
-    else:
-        raise ValueError("Must provide either slc_files or burst_id_date_tuples")
-
-
-def _duplicated_bursts(burst_id_to_dates: Mapping[str, Sequence[datetime]]):
-    from collections import Counter
-
-    counts: Counter = Counter()
-    for burst_id, d_list in burst_id_to_dates.items():
-        for d in d_list:
-            counts[(burst_id, d)] += 1
-    # total_sum = sum([len(v) for k, v in burst_id_to_dates.items()])
-    # deduped_sum = sum([len(set(v)) for k, v in burst_id_to_dates.items()])
-    return [pair for pair, count in counts.items() if count > 1]
-
-
 def get_missing_data_options(
     slc_files: Optional[Iterable[Filename]] = None,
     burst_id_date_tuples: Optional[Iterable[tuple[str, datetime]]] = None,
@@ -135,6 +92,49 @@ def get_missing_data_options(
     # - Each row corresponds to one of the possible burst IDs
     # - Each column corresponds to one of the possible dates
     return generate_burst_subset_options(B, all_burst_ids, all_dates)
+
+
+def get_burst_id_to_dates(
+    slc_files: Optional[Iterable[Filename]] = None,
+    burst_id_date_tuples: Optional[Iterable[tuple[str, datetime]]] = None,
+) -> dict[str, list[datetime]]:
+    """Get a mapping of burst ID to list of dates.
+
+    Assumes that the `slc_files` have only one datetime in the name, or
+    that the first datetime in the `burst_id_date_tuples` is the relevant
+    one (as is the case for OPERA CSLCs).
+
+
+    Parameters
+    ----------
+    slc_files : Optional[Iterable[Filename]]
+        List of OPERA CSLC filenames.
+    burst_id_date_tuples : Optional[Iterable[tuple[str, datetime]]]
+        Alternative input: list of all existing (burst_id, datetime) tuples.
+
+    Returns
+    -------
+    dict[str, list[datetime]]
+        Mapping of burst ID to list of dates.
+    """
+    if slc_files is not None:
+        return _burst_id_mapping_from_files(slc_files)
+    elif burst_id_date_tuples is not None:
+        return _burst_id_mapping_from_tuples(burst_id_date_tuples)
+    else:
+        raise ValueError("Must provide either slc_files or burst_id_date_tuples")
+
+
+def _duplicated_bursts(burst_id_to_dates: Mapping[str, Sequence[datetime]]):
+    from collections import Counter
+
+    counts: Counter = Counter()
+    for burst_id, d_list in burst_id_to_dates.items():
+        for d in d_list:
+            counts[(burst_id, d)] += 1
+    # total_sum = sum([len(v) for k, v in burst_id_to_dates.items()])
+    # deduped_sum = sum([len(set(v)) for k, v in burst_id_to_dates.items()])
+    return [pair for pair, count in counts.items() if count > 1]
 
 
 def get_burst_id_date_incidence(


### PR DESCRIPTION
With only `download` as a function, we can't use the `missing_data` functionality.

Now we can see what consistent subset options there are beforehand. For example,

```python
results, mdos = opera_utils.download.search_cslcs(bounds=bbox, start="2022-10-01", end="2023-10-15", check_missing_data=True)
```
Now we can see there are 2 options for this
```python
In [18]: mdos
Out[18]: 

[
    BurstSubsetOption(
        total_num_bursts=310,
        burst_ids=(
            't064_135527_iw2',
            't064_135528_iw2',
            't064_135528_iw3',
            't064_135529_iw2',
            't064_135529_iw3',
            't064_135530_iw2',
            't071_151216_iw2',
            't071_151217_iw2',
            't071_151218_iw2',
            't071_151219_iw2'
        ),
        dates=(
            datetime.datetime(2022, 10, 4, 0, 0),
......
            datetime.datetime(2023, 10, 11, 0, 0)
        ),
        num_candidate_bursts=314
    ),
    BurstSubsetOption(
        total_num_bursts=128,
        burst_ids=('t071_151218_iw2', 't071_151219_iw2', 't071_151216_iw2', 't071_151217_iw2'),
        dates=(
            datetime.datetime(2022, 10, 4, 0, 0),
...
            datetime.datetime(2023, 9, 29, 0, 0),
            datetime.datetime(2023, 10, 11, 0, 0)
        ),
        num_candidate_bursts=314
    )
]
In [19]: len(mdos[0].dates)
Out[19]: 31

In [20]: len(mdos[1].dates)
Out[20]: 32

```
There was one extra date for a few burst IDs. If we exclude that date, then all 10 burst IDs have a consistent set of image dates.