### PR TITLE
use `NBITS=16` when saving LOS files

### DIFF
--- a/src/opera_utils/constants.py
+++ b/src/opera_utils/constants.py
@@ -34,6 +34,6 @@ EXTRA_COMPRESSED_TIFF_OPTIONS = (
     *DEFAULT_TIFF_OPTIONS,
     # Note: we're dropping mantissa bits before we do not
     # need prevision for LOS rasters (or incidence)
-    "DISCARD_LSB=6",
+    "NBITS=16",
     "PREDICTOR=2",
 )

--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -228,7 +228,11 @@ def _download_for_burst_ids(
     if product == L2Product.CSLC:
         logger.debug(f"Found {len(results)} total results before deduping pgeVersion")
         results = filter_results_by_date_and_version(results)
-    logger.info(f"Found {len(results)} results")
+
+    msg = f"Found {len(results)} results"
+    if len(results) == 0:
+        raise ValueError(msg)
+    logger.info(msg)
     session = _get_auth_session()
     urls = _get_urls(results)
     asf.download_urls(


### PR DESCRIPTION
```python
In [5]: fn = 'los_east.tif'
In [6]: r1 = io.load_gdal(Path("current") / fn); r2 = io.load_gdal(Path("nbits16") / fn)

# Largest difference between `main` and new version
In [7]: np.max(np.abs(r1 - r2))
Out[7]: 0.00048828125

# relative error:
In [10]: np.max(np.abs(r1 - r2)) / np.max(np.abs(r1))
Out[10]: 0.00068804994
```
New version is ~1/4 the size for the LOS files
```
(mapping-311) staniewi:opera-utils$ ls -lh l*tif current/
-rw-r--r--  1 staniewi  staff   156K Jul 15 21:50 layover_shadow_mask.tif
-rw-r--r--  1 staniewi  staff   1.3M Jul 15 21:50 los_east.tif
-rw-r--r--  1 staniewi  staff   1.5M Jul 15 21:50 los_north.tif
(mapping-311) staniewi:opera-utils$ ls -lh nbits16/
total 1672
-rw-r--r--  1 staniewi  staff   156K Jul 15 20:45 layover_shadow_mask.tif
-rw-r--r--  1 staniewi  staff   350K Jul 15 20:45 los_east.tif
-rw-r--r--  1 staniewi  staff   328K Jul 15 20:45 los_north.tif
```