### PR TITLE
Fix second datetime in CSLC name to be `generation_datetime`

### DIFF
--- a/src/opera_utils/_cslc.py
+++ b/src/opera_utils/_cslc.py
@@ -59,7 +59,7 @@ def parse_filename(h5_filename: Filename) -> dict[str, str | datetime]:
         - product_type: str
         - burst_id: str (normalized to lowercase with underscores)
         - start_datetime: datetime
-        - end_datetime: datetime
+        - generation_datetime: datetime
         - sensor: str
         - polarization: str
         - product_version: str
@@ -101,9 +101,9 @@ def _parse_cslc_product(match: re.Match):
     result["start_datetime"] = datetime.strptime(result["start_datetime"], fmt).replace(
         tzinfo=timezone.utc
     )
-    result["end_datetime"] = datetime.strptime(result["end_datetime"], fmt).replace(
-        tzinfo=timezone.utc
-    )
+    result["generation_datetime"] = datetime.strptime(
+        result["generation_datetime"], fmt
+    ).replace(tzinfo=timezone.utc)
     return result
 
 

--- a/src/opera_utils/_cslc.py
+++ b/src/opera_utils/_cslc.py
@@ -469,14 +469,7 @@ def create_nodata_mask(
     with tempfile.TemporaryDirectory() as tmpdir:
         temp_vector_file = Path(tmpdir) / "temp.geojson"
         with open(temp_vector_file, "w") as f:
-            f.write(
-                json.dumps(
-                    {
-                        "geometry": geometry.mapping(union_poly),
-                        "properties": {"id": 1},
-                    }
-                )
-            )
+            f.write(json.dumps(geometry.mapping(union_poly)))
 
         # Open the input vector file
         src_ds = gdal.OpenEx(fspath(temp_vector_file), gdal.OF_VECTOR)

--- a/src/opera_utils/constants.py
+++ b/src/opera_utils/constants.py
@@ -23,7 +23,7 @@ CSLC_S1_FILE_REGEX = (
     r"(?P<burst_id>T\d{3}-\d+-IW\d)_"
     r"(?P<start_datetime>\d{8}T\d{6}Z)_"
     r"(?P<generation_datetime>\d{8}T\d{6}Z)_"
-    r"(?P<sensor>S1[AB])_"
+    r"(?P<sensor>S1[ABCDE])_"
     r"(?P<polarization>VV|HH)_"
     r"v(?P<product_version>\d+\.\d+)"
 )

--- a/src/opera_utils/constants.py
+++ b/src/opera_utils/constants.py
@@ -22,7 +22,7 @@ CSLC_S1_FILE_REGEX = (
     r"(?P<product_type>CSLC-S1)_"
     r"(?P<burst_id>T\d{3}-\d+-IW\d)_"
     r"(?P<start_datetime>\d{8}T\d{6}Z)_"
-    r"(?P<end_datetime>\d{8}T\d{6}Z)_"
+    r"(?P<generation_datetime>\d{8}T\d{6}Z)_"
     r"(?P<sensor>S1[AB])_"
     r"(?P<polarization>VV|HH)_"
     r"v(?P<product_version>\d+\.\d+)"

--- a/tests/test_cslc.py
+++ b/tests/test_cslc.py
@@ -63,7 +63,7 @@ def test_file_regex():
         "start_datetime": datetime.datetime(
             2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
         ),
-        "end_datetime": datetime.datetime(
+        "generation_datetime": datetime.datetime(
             2023, 1, 2, 23, 59, 59, tzinfo=datetime.timezone.utc
         ),
         "sensor": "S1B",

--- a/tests/test_cslc.py
+++ b/tests/test_cslc.py
@@ -43,7 +43,7 @@ def test_file_regex():
         "start_datetime": datetime.datetime(
             2024, 7, 16, 10, 57, 12, tzinfo=datetime.timezone.utc
         ),
-        "end_datetime": datetime.datetime(
+        "generation_datetime": datetime.datetime(
             2024, 7, 17, 7, 32, 55, tzinfo=datetime.timezone.utc
         ),
         "sensor": "S1A",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,6 +3,16 @@ import pytest
 from opera_utils import datasets
 
 
+# XXX remove this ones release for https://github.com/kevin1024/vcrpy/issues/888 is out
+@pytest.fixture(autouse=True)
+def patch_VCRHTTPResponse_version_string():
+    from vcr.stubs import VCRHTTPResponse
+
+    if not hasattr(VCRHTTPResponse, "version_string"):
+        VCRHTTPResponse.version_string = None
+    yield
+
+
 @pytest.fixture(scope="module")
 def vcr_config():
     return {

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6,6 +6,16 @@ import pytest
 from opera_utils.download import L2Product, filter_results_by_date_and_version
 
 
+# XXX remove this ones release for https://github.com/kevin1024/vcrpy/issues/888 is out
+@pytest.fixture(autouse=True)
+def patch_VCRHTTPResponse_version_string():
+    from vcr.stubs import VCRHTTPResponse
+
+    if not hasattr(VCRHTTPResponse, "version_string"):
+        VCRHTTPResponse.version_string = None
+    yield
+
+
 @pytest.mark.filterwarnings(
     "ignore:Parsing dates involving a day of month without a year specified.*:DeprecationWarning"
 )


### PR DESCRIPTION
The second date is not the end of the acquisition, as it is for the SAFE granules; it is data production/generation datetime.

Also fixes two issues from CI:
- GDAL 3.10 changed the strictness with which it accepts GeoJSON
- VcrPy has a temporary issue from upstream urllib changes