### PR TITLE
`download.py`: Add `download_rtcs` and `download_rtc_static_layers`

### DIFF
--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -90,8 +90,9 @@ def download_rtc_static_layers(
     """
     selected_layers = [RTCStaticLayers(layer) for layer in layers]
 
+    normalized_burst_ids = list(map(normalize_burst_id, burst_ids))
     results = asf.search(
-        operaBurstID=list(map(normalize_burst_id, burst_ids)),
+        operaBurstID=normalized_burst_ids,
         processingLevel=L2Product.RTC_STATIC.value,
         dataset=asf.DATASET.OPERA_S1,
     )
@@ -124,6 +125,12 @@ def download_rtc_static_layers(
                 out_path = Path(output_dir) / Path(urllib.parse.urlparse(u).path).name
                 out_paths.append(out_path)
 
+    if not out_paths:
+        raise ValueError(
+            f"No urls found for {normalized_burst_ids} and {selected_layers}"
+        )
+
+    Path(output_dir).mkdir(exist_ok=True, parents=True)
     asf.download_urls(
         urls=urls, path=str(output_dir), session=session, processes=max_jobs
     )
@@ -396,6 +403,7 @@ def _download_for_burst_ids(
     logger.info(msg)
     session = _get_auth_session()
     urls = get_urls(results)
+    Path(output_dir).mkdir(exist_ok=True, parents=True)
     asf.download_urls(
         urls=urls, path=str(output_dir), session=session, processes=max_jobs
     )

--- a/src/opera_utils/download.py
+++ b/src/opera_utils/download.py
@@ -27,6 +27,8 @@ __all__ = [
     "search_cslcs",
     "download_cslc_static_layers",
     "search_cslc_static_layers",
+    "download_rtcs",
+    "download_rtc_static_layers",
     "get_urls",
 ]
 
@@ -72,6 +74,35 @@ def download_cslc_static_layers(
         output_dir=output_dir,
         max_jobs=max_jobs,
         product=L2Product.CSLC_STATIC,
+    )
+
+
+def download_rtc_static_layers(
+    burst_ids: Sequence[str],
+    output_dir: PathOrStr,
+    max_jobs: int = 3,
+) -> list[Path]:
+    """Download the RTC-S1 static layers for a sequence of burst IDs.
+
+    Parameters
+    ----------
+    burst_ids : Sequence[str]
+        Sequence of OPERA Burst IDs (e.g. 'T123_012345_IW1')
+    output_dir : Path | str
+        Location to save output rasters to
+    max_jobs : int, optional
+        Number of parallel downloads to run, by default 3
+
+    Returns
+    -------
+    list[Path]
+        Locations to saved raster files.
+    """
+    return _download_for_burst_ids(
+        burst_ids=burst_ids,
+        output_dir=output_dir,
+        max_jobs=max_jobs,
+        product=L2Product.RTC_STATIC,
     )
 
 
@@ -155,7 +186,7 @@ def download_cslcs(
     end: DatetimeInput = None,
     max_jobs: int = 3,
 ) -> list[Path]:
-    """Download the static layers for a sequence of burst IDs.
+    """Download the matching CSLC-S1 files for a sequence of burst IDs.
 
     Parameters
     ----------
@@ -182,6 +213,43 @@ def download_cslcs(
         start=start,
         end=end,
         product=L2Product.CSLC,
+    )
+
+
+def download_rtcs(
+    burst_ids: Sequence[str],
+    output_dir: PathOrStr,
+    start: DatetimeInput = None,
+    end: DatetimeInput = None,
+    max_jobs: int = 3,
+) -> list[Path]:
+    """Download the matching RTC-S1 files for a sequence of burst IDs.
+
+    Parameters
+    ----------
+    burst_ids : Sequence[str]
+        Sequence of OPERA Burst IDs (e.g. 'T123_012345_IW1')
+    output_dir : Path | str
+        Location to save output rasters to
+    start: datetime.datetime | str, optional
+        Start date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+    end: datetime.datetime | str, optional
+        end: End date of data acquisition. Supports timestamps as well as natural language such as "3 weeks ago"
+    max_jobs : int, optional
+        Number of parallel downloads to run, by default 3
+
+    Returns
+    -------
+    list[Path]
+        Locations to saved raster files.
+    """
+    return _download_for_burst_ids(
+        burst_ids=burst_ids,
+        output_dir=output_dir,
+        max_jobs=max_jobs,
+        start=start,
+        end=end,
+        product=L2Product.RTC,
     )
 
 


### PR DESCRIPTION
This PR adds the ability to download any of the RTC-S1 static layers files. An example usage for getting all rasters for a DISP-S1 frame:

```python
opera_utils.download.download_rtc_static_layers(
    opera_utils.get_burst_ids_for_frame(11115),
    output_dir=Path("rtc_static"),
    layers=['mask']
)
```

You can also request multiple layers, e.g. `layers=['mask', 'local_incidence_angle']`.