### PR TITLE
Use `pyproject` sections instead of `*/requirements.txt`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          pip install --no-deps .[test]
+          pip install .[test]
       - name: Test
         run: |
           pytest -n0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          pip install --no-deps .
-      - name: Install test dependencies
-        run: |
-          micromamba install -f tests/requirements.txt -c conda-forge
+          pip install --no-deps .[test]
       - name: Test
         run: |
           pytest -n0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,6 @@ repos:
         args: [--allow-multiple-documents]
       - id: debug-statements
       - id: end-of-file-fixer
-      - id: file-contents-sorter
-        files: (requirements.txt)$
       - id: mixed-line-ending
       - id: trailing-whitespace
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,0 @@
-# mkdocs requirements
-mkdocs
-mkdocs-gen-files
-mkdocs-jupyter
-mkdocs-literate-nav
-mkdocs-material
-mkdocs-section-index
-mkdocstrings[python]
-pymdown-extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ Changelog = "https://github.com/opera-adt/opera-utils/releases"
 [project.scripts]
 opera-utils = "opera_utils.cli:cli_app"
 
-# extra requirements: `pip install .[docs]` or `pip install .[docs]`
+# extra requirements: `pip install .[docs]` or `pip install .[test]`
 [project.optional-dependencies]
 test = [
   "asf_search",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,17 +19,29 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
 license = { file = "LICENSE.txt" }
 
+dependencies = [
+  "click>=7.0",
+  "h5py>=1.10",
+  "numpy>=1.24",
+  "pooch>=1.7",
+  "pyproj>=3.3",
+  "shapely>=1.8",
+  "typing_extensions>=4",
+]
+
+
 # The version will be written into a version.py upon install, auto-generated
 # see section: setuptools_scm
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 # dependencies will be read from text files
-dynamic = ["version", "dependencies", "optional-dependencies"]
+dynamic = ["version"]
 
 [project.urls]
 Homepage = "https://github.com/opera-adt/opera-utils"
@@ -41,14 +53,29 @@ Changelog = "https://github.com/opera-adt/opera-utils/releases"
 [project.scripts]
 opera-utils = "opera_utils.cli:cli_app"
 
-[tool.setuptools.dynamic]
-dependencies = { file = ["requirements.txt"] }
-
 # extra requirements: `pip install .[docs]` or `pip install .[docs]`
-[tool.setuptools.dynamic.optional-dependencies.docs]
-file = ["docs/requirements.txt"]
-[tool.setuptools.dynamic.optional-dependencies.test]
-file = ["tests/requirements.txt"]
+[project.optional-dependencies]
+test = [
+  "asf_search",
+  "pre-commit",
+  "pytest",
+  "pytest-cov",
+  "pytest-randomly",
+  "pytest-recording",
+  "pytest-xdist",
+  "ruff",
+]
+docs = [
+  "mkdocs",
+  "mkdocs-gen-files",
+  "mkdocs-jupyter",
+  "mkdocs-literate-nav",
+  "mkdocs-material",
+  "mkdocs-section-index",
+  "mkdocstrings[python]",
+  "pybtex",               # for mdx_bib
+  "pymdown-extensions",
+]
 
 [tool.setuptools_scm]
 # https://github.com/pypa/setuptools_scm#configuration-parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-h5py>=1.10
-pooch>=1.7
-shapely>=1.8

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,8 +1,0 @@
-asf_search
-pre-commit
-pytest
-pytest-cov
-pytest-randomly
-pytest-recording
-pytest-xdist
-ruff


### PR DESCRIPTION
Cuts down the 3 `requirements.txt` files in favor of listing out the dependencies in `pyproject.toml` directly.