### PR TITLE
Add `credentials` and `disp._remote` module with `open_h5` for https/s3 access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
               - conda-forge
       - name: Install
         run: |
-          pip install .[test]
+          pip install .[test,remote]
       - name: Test
         run: |
           pytest -n0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,10 @@ opera-utils = "opera_utils.cli:cli_app"
 
 # extra requirements: `pip install .[docs]` or `pip install .[test]`
 [project.optional-dependencies]
+# For geopandas functionality with burst/frame databases:
 geopandas = ["geopandas", "pyogrio"]
+# Access remote hdf5 files over S3 or HTTPS:
+remote = ["aiohttp", "fsspec", "s3fs"]
 
 test = [
   "asf_search",

--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import netrc
 import os
 from dataclasses import dataclass

--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -7,6 +7,12 @@ from typing import Self
 
 import requests
 
+__all__ = [
+    "AWSCredentials",
+    "get_earthdata_username_password",
+    "get_temporary_aws_credentials",
+]
+
 
 class EarthdataLoginFailure(Exception):
     """Exception raised when Earthdata Login credentials are not found."""

--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -3,9 +3,9 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from functools import cache
-from typing import Self
 
 import requests
+from typing_extensions import Self
 
 __all__ = [
     "AWSCredentials",

--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -1,0 +1,188 @@
+import netrc
+import os
+from dataclasses import dataclass
+from enum import Enum
+from functools import cache
+from typing import Self
+
+import requests
+
+
+class EarthdataLoginFailure(Exception):
+    """Exception raised when Earthdata Login credentials are not found."""
+
+    pass
+
+
+class ASFCredentialEndpoints(Enum):
+    """Enumeration of ASF temporary credentials endpoints.
+
+    See READMEs of the endpoints for more information, e.g.
+    https://cumulus.asf.alaska.edu/s3credentialsREADME
+    """
+
+    OPERA = "https://cumulus.asf.alaska.edu/s3credentials"
+    OPERA_UAT = "https://cumulus-test.asf.alaska.edu/s3credentials"
+    SENTINEL1 = "https://sentinel1.asf.alaska.edu/s3credentials"
+
+
+@dataclass
+class AWSCredentials:
+    """AWS credentials for direct S3 access."""
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+
+    def to_env(self) -> dict[str, str]:
+        """Return the environment variable format of values: `AWS_`.
+
+        Settable using os.environ.
+        """
+        return {
+            "AWS_ACCESS_KEY_ID": self.access_key_id,
+            "AWS_SECRET_ACCESS_KEY": self.secret_access_key,
+            "AWS_SESSION_TOKEN": self.session_token,
+        }
+
+    def to_h5py_kwargs(self) -> dict[str, str]:
+        return {
+            "secret_id": self.access_key_id,
+            "secret_key": self.secret_access_key,
+            "session_token": self.session_token,
+        }
+
+    @classmethod
+    def from_asf(
+        cls, endpoint: str | ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA
+    ) -> Self:
+        """Get temporary AWS S3 access credentials.
+
+        Requests new credentials if credentials are expired, or gets from the cache.
+
+        Assumes Earthdata Login credentials are available via a .netrc file,
+        or via EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables.
+        """
+        data = get_temporary_aws_credentials(ASFCredentialEndpoints(endpoint))
+        return cls(
+            access_key_id=data["accessKeyId"],
+            secret_access_key=data["secretAccessKey"],
+            session_token=data["sessionToken"],
+        )
+
+    @classmethod
+    def from_env(cls) -> Self:
+        """Get AWS credentials from 'AWS_*' environment variables.
+
+        Required environment variables:
+            AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+
+        Raises
+        ------
+        KeyError
+            If any of the required environment variables are not set.
+        """
+        return cls(
+            access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+            secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
+            session_token=os.environ["AWS_SESSION_TOKEN"],
+        )
+
+
+@cache
+def get_temporary_aws_credentials(
+    endpoint: ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA,
+    earthdata_username: str | None = None,
+    earthdata_password: str | None = None,
+    host: str = "urs.earthdata.nasa.gov",
+) -> dict[str, str]:
+    """Get temporary AWS S3 access credentials.
+
+    Requests new credentials if credentials are expired, or gets from the cache.
+    Earthdata arguments are used to request new S3 credentials from ASF.
+
+    Parameters
+    ----------
+    endpoint : ASFCredentialEndpoints
+        The endpoint to request credentials from.
+        Default is OPERA.
+    earthdata_username : str | None
+        Earthdata Login username.
+    earthdata_password : str | None
+        Earthdata Login password.
+    host : str
+        The host for which to authenticate using netrc.
+        Default is "urs.earthdata.nasa.gov".
+
+    Returns
+    -------
+    dict:
+        JSON response from s3credentials URL.
+
+    Raises
+    ------
+    EarthdataLoginFailure
+        If the Earthdata Login credentials are not found.
+    requests.exceptions.HTTPError
+        If the request to the endpoint fails.
+
+    """
+    username, password = get_earthdata_username_password(
+        earthdata_username, earthdata_password, host
+    )
+    auth = (username, password)
+    resp = requests.get(endpoint.value, auth=auth)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_earthdata_username_password(
+    earthdata_username: str | None = None,
+    earthdata_password: str | None = None,
+    host: str = "urs.earthdata.nasa.gov",
+) -> tuple[str, str]:
+    """Get Earthdata Login credentials.
+
+    Parameters
+    ----------
+    earthdata_username : str | None
+        Earthdata Login username.
+    earthdata_password : str | None
+        Earthdata Login password.
+    host : str
+        The host for which to authenticate using netrc.
+        Default is "urs.earthdata.nasa.gov".
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple containing the username and password.
+
+    Raises
+    ------
+    ValueError
+        If no credentials are found.
+    """
+    # Case 1: Use provided credentials if both are specified
+    if earthdata_username and earthdata_password:
+        return earthdata_username, earthdata_password
+
+    # Case 2: Try to get credentials from .netrc file
+    try:
+        auth = netrc.netrc().authenticators(host)
+        if auth and auth[0] and auth[2]:
+            return auth[0], auth[2]
+    except (FileNotFoundError, netrc.NetrcParseError):
+        pass
+
+    # Case 3: Try to get credentials from environment variables
+    username = os.environ.get("EARTHDATA_USERNAME", "")
+    password = os.environ.get("EARTHDATA_PASSWORD", "")
+    if username and password:
+        return username, password
+
+    # No valid credentials found
+    raise ValueError(
+        "No credentials found: neither valid parameters provided, .netrc file has a"
+        f" '{host}' entry, nor environment variables set."
+    )

--- a/src/opera_utils/disp/__init__.py
+++ b/src/opera_utils/disp/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._product import DispProduct, DispProductStack
 from ._utils import get_frame_coordinates
 

--- a/src/opera_utils/disp/__init__.py
+++ b/src/opera_utils/disp/__init__.py
@@ -1,4 +1,10 @@
 from ._product import DispProduct, DispProductStack
 from ._utils import get_frame_coordinates
 
-__all__ = ["DispProduct", "DispProductStack", "get_frame_coordinates"]
+# Remote access is based on optional dependencies
+try:
+    from ._remote import open_h5
+except ImportError:
+    pass
+
+__all__ = ["DispProduct", "DispProductStack", "open_h5", "get_frame_coordinates"]

--- a/src/opera_utils/disp/_product.py
+++ b/src/opera_utils/disp/_product.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -115,6 +116,9 @@ class DispProduct:
         )
         profile["crs"] = f"EPSG:{self.epsg}"
         return profile
+
+    def __fspath__(self) -> str:
+        return os.fspath(self.filename)
 
 
 @dataclass

--- a/src/opera_utils/disp/_remote.py
+++ b/src/opera_utils/disp/_remote.py
@@ -1,0 +1,165 @@
+from contextlib import contextmanager
+from os import fsdecode
+from pathlib import Path
+from typing import Generator
+
+import aiohttp
+import fsspec
+import h5py
+import s3fs
+
+from opera_utils.credentials import AWSCredentials, get_earthdata_username_password
+
+__all__ = ["open_h5"]
+
+
+@contextmanager
+def open_h5(
+    url: str | Path,
+    page_size: int = 4 * 1024 * 1024,
+    rdcc_nbytes: int = 1024 * 1024 * 1000,
+    earthdata_username: str | None = None,
+    earthdata_password: str | None = None,
+    host: str = "urs.earthdata.nasa.gov",
+    asf_endpoint: str = "opera",
+) -> Generator[h5py.File, None, None]:
+    """Context manager to open a remote (or local) HDF5 file.
+
+    Can handle both HTTPS access (your Earthdata login credentials) and
+    S3 URLs (for direct S3 access via temporary AWS credentials).
+
+    Note that direct S3 access is only available for Earthdata granules
+    if you are running on an in-region EC2 instance.
+
+    For HTTPS access, the Earthdata Login credentials are used to authenticate
+    the request. There are 3 methods of providing the login credentials:
+    1. Directly passed as arguments
+    2. From the ~.netrc file
+    3. From environment variables EARTHDATA_USERNAME and EARTHDATA_PASSWORD.
+
+    For S3 access, AWS credentials required.
+    They will be retrieved from the environment variables
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN, or
+    temporary AWS credentials can be requested from ASF using the
+    Earthdata Login credentials.
+
+    Parameters
+    ----------
+    url : str
+        The URL of the HDF5 file to be accessed. Can be a local file path, an
+        HTTPS URL, or an S3 URL.
+    page_size : int, optional
+        The page size to use for the HDF5 file.
+        Default is 4MB.
+        Must be a power of 2 and larger than the page size used to create the
+        HDF5 file (which is 4 MB for OPERA DISP-S1)
+    rdcc_nbytes : int
+        The number of bytes to use for the read cache.
+        Default is 1000MB.
+    earthdata_username : str | None, optional
+        Earthdata Login username, if environment variables are not set.
+    earthdata_password : str | None, optional
+        Earthdata Login password, if environment variables are not set.
+    host : str, optional
+        (For S3 access) The host used to request temporary AWS credentials.
+        Default is "urs.earthdata.nasa.gov".
+    asf_endpoint : str, optional
+        (For S3 access) The ASF endpoint to use for temporary AWS credentials.
+        Default is "opera".
+
+
+    Yields
+    ------
+    Generator[h5py.File, None, None]
+        Generator for the opened HDF5 file.
+
+    Raises
+    ------
+    ValueError
+        If the .netrc file does not contain authentication information for the
+        specified host.
+
+    """
+    if isinstance(url, Path):
+        url_str = fsdecode(url.resolve().as_uri())
+
+    if url_str.startswith("http"):
+        fs = get_https_fs(earthdata_username, earthdata_password, host)
+    elif url_str.startswith("s3://"):
+        fs = get_s3_fs(asf_endpoint=asf_endpoint)
+    elif url_str.startswith("file://"):
+        fs = fsspec.filesystem("file")
+    else:
+        raise ValueError(f"Unrecognized scheme for {url}")
+
+    # h5py arguments used to set the "cloud-friendly" parameters
+    cloud_kwargs = dict(fs_page_size=page_size, rdcc_nbytes=rdcc_nbytes)
+    # Create the Open File-like object from fsspec
+    byte_stream = fs.open(path=url, mode="rb", cache_type="first")
+    with h5py.File(byte_stream, mode="r", **cloud_kwargs) as hf:
+        yield hf
+
+
+def get_https_fs(
+    earthdata_username: str | None = None,
+    earthdata_password: str | None = None,
+    host="urs.earthdata.nasa.gov",
+) -> fsspec.AbstractFileSystem:
+    """Create an fsspec filesystem object authenticated using netrc for HTTP access.
+
+    Parameters
+    ----------
+    earthdata_username : str | None
+        Earthdata Login username, if environment variables are not set.
+    earthdata_password : str | None
+        Earthdata Login password, if environment variables are not set.
+    host : str, optional
+        The host for which to authenticate using netrc.
+        Default is "urs.earthdata.nasa.gov".
+
+    Returns
+    -------
+    fsspec.AbstractFileSystem
+        An authenticated fsspec filesystem object for HTTP access.
+
+    Raises
+    ------
+    ValueError
+        If the .netrc file does not contain authentication information for the
+        specified host.
+
+    """
+    username, password = get_earthdata_username_password(
+        earthdata_username, earthdata_password, host=host
+    )
+
+    fs = fsspec.filesystem(
+        "https", client_kwargs={"auth": aiohttp.BasicAuth(username, password)}
+    )
+    return fs
+
+
+def get_s3_fs(asf_endpoint: str = "opera") -> s3fs.S3FileSystem:
+    """Create an fsspec filesystem object authenticated using temporary AWS credentials.
+
+    Parameters
+    ----------
+    asf_endpoint : str, optional
+        The ASF endpoint to use for temporary AWS credentials, by default "opera"
+        Choices are "opera", "opera-uat"
+
+    Returns
+    -------
+    s3fs.S3FileSystem
+        An authenticated fsspec filesystem object for S3 access.
+    """
+    try:
+        creds = AWSCredentials.from_env()
+    except KeyError:
+        creds = AWSCredentials.from_asf(asf_endpoint)
+    s3_fs = s3fs.S3FileSystem(
+        key=creds.access_key_id,
+        secret=creds.secret_access_key,
+        token=creds.session_token,
+    )
+    return s3_fs

--- a/src/opera_utils/disp/_remote.py
+++ b/src/opera_utils/disp/_remote.py
@@ -1,7 +1,5 @@
-from contextlib import contextmanager
 from os import fsdecode
 from pathlib import Path
-from typing import Generator
 
 import aiohttp
 import fsspec
@@ -13,7 +11,6 @@ from opera_utils.credentials import AWSCredentials, get_earthdata_username_passw
 __all__ = ["open_h5"]
 
 
-@contextmanager
 def open_h5(
     url: str | Path,
     page_size: int = 4 * 1024 * 1024,
@@ -22,8 +19,8 @@ def open_h5(
     earthdata_password: str | None = None,
     host: str = "urs.earthdata.nasa.gov",
     asf_endpoint: str = "opera",
-) -> Generator[h5py.File, None, None]:
-    """Context manager to open a remote (or local) HDF5 file.
+) -> h5py.File:
+    """Open a remote (or local) HDF5 file.
 
     Can handle both HTTPS access (your Earthdata login credentials) and
     S3 URLs (for direct S3 access via temporary AWS credentials).
@@ -55,7 +52,7 @@ def open_h5(
         HDF5 file (which is 4 MB for OPERA DISP-S1)
     rdcc_nbytes : int
         The number of bytes to use for the read cache.
-        Default is 1000MB.
+        Default is 1GB
     earthdata_username : str | None, optional
         Earthdata Login username, if environment variables are not set.
     earthdata_password : str | None, optional
@@ -68,10 +65,10 @@ def open_h5(
         Default is "opera".
 
 
-    Yields
-    ------
-    Generator[h5py.File, None, None]
-        Generator for the opened HDF5 file.
+    Returns
+    -------
+    h5py.File
+        An opened HDF5 file.
 
     Raises
     ------
@@ -95,8 +92,7 @@ def open_h5(
     cloud_kwargs = dict(fs_page_size=page_size, rdcc_nbytes=rdcc_nbytes)
     # Create the Open File-like object from fsspec
     byte_stream = fs.open(path=url, mode="rb", cache_type="first")
-    with h5py.File(byte_stream, mode="r", **cloud_kwargs) as hf:
-        yield hf
+    return h5py.File(byte_stream, mode="r", **cloud_kwargs)
 
 
 def get_https_fs(

--- a/src/opera_utils/disp/_remote.py
+++ b/src/opera_utils/disp/_remote.py
@@ -80,8 +80,7 @@ def open_h5(
         specified host.
 
     """
-    if isinstance(url, Path):
-        url_str = fsdecode(url.resolve().as_uri())
+    url_str = fsdecode(url.resolve().as_uri()) if isinstance(url, Path) else str(url)
 
     if url_str.startswith("http"):
         fs = get_https_fs(earthdata_username, earthdata_password, host)

--- a/src/opera_utils/disp/_utils.py
+++ b/src/opera_utils/disp/_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import itertools
 from collections.abc import Iterable, Sequence

--- a/src/opera_utils/disp/search.py
+++ b/src/opera_utils/disp/search.py
@@ -152,6 +152,7 @@ def get_products(
     product_version: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
+    url_type: Literal["s3", "https"] = "https",
     use_uat: bool = False,
 ) -> list[Granule]:
     """Query the CMR for granules matching the given frame ID and product version.
@@ -166,6 +167,9 @@ def get_products(
         The start of the temporal range in UTC.
     end_datetime : datetime, optional
         The end of the temporal range in UTC.
+    url_type : Literal["s3", "https"]
+        The protocol to use for downloading, either "s3" or "https".
+        Default is "https".
     use_uat : bool
         Whether to use the UAT environment.
         Default is False (uses main Earthdata environment)
@@ -212,7 +216,9 @@ def get_products(
         response = requests.get(search_url, params=params, headers=headers)
         response.raise_for_status()
         data = response.json()
-        cur_granules = [Granule.from_umm(item["umm"]) for item in data["items"]]
+        cur_granules = [
+            Granule.from_umm(item["umm"], url_type=url_type) for item in data["items"]
+        ]
         # CMR filters apply to both the reference and secondary time (as of 2025-03-29)
         # We want to filter just by the secondary time
         granules.extend(

--- a/tests/cassettes/test_credentials/test_get_temporary_aws_credentials.yaml
+++ b/tests/cassettes/test_credentials/test_get_temporary_aws_credentials.yaml
@@ -1,0 +1,550 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:15 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 a9dc097bbaf22a663c80eb85450d7cce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0sU6UiNGOAJhPtlhEtG-ykhii9yUGbN8cGP_hMaJDqS1CSjP1a3Q2A==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f5228f-0e4f7f7749b8039c7a7818b4;Parent=42df9db2959b28fe;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://cumulus.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+      x-amz-apigw-id:
+      - ItJWbEf2vHcEW-w=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:15 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.234
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 07c0d2cc-05bb-4c73-b22d-d63a2f5136d4
+      x-amzn-RequestId:
+      - 4f668138-dfe5-4c60-846a-e5d727f18181
+      x-request-id:
+      - 985b13f3-c0a7-4767-b0e8-87abb5da5c3b
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Authorization:
+      - Basic c2NvdHQuc3RhbmllOlE1TnU0I0xxdHIzbQ==
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://cumulus.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+  response:
+    body:
+      string: You are being redirected to https://cumulus.asf.alaska.edu/login?code=hVrDQCoou4KqtdBIdEN-wBNr2hbG_X_6FvWnYEZwR4dEdtde5JdtNopggrXNBFWlkdt6NK34sIGmuD5_IfJi1S5XHTMtYRcyMuAEGcg&state=%2Fs3credentials
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Origin:
+      - 'null'
+      Access-Control-Expose-Headers:
+      - 'true'
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 08 Apr 2025 13:20:15 GMT
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Location:
+      - https://cumulus.asf.alaska.edu/login?code=hVrDQCoou4KqtdBIdEN-wBNr2hbG_X_6FvWnYEZwR4dEdtde5JdtNopggrXNBFWlkdt6NK34sIGmuD5_IfJi1S5XHTMtYRcyMuAEGcg&state=%2Fs3credentials
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Set-Cookie:
+      - urs_user_already_logged=yes; domain=earthdata.nasa.gov; path=/; expires=Wed,
+        09 Apr 2025 13:20:15 GMT; secure; HttpOnly; SameSite=Lax
+      - _urs-gui_session=3335395f7cc3b927a9680a6b25e63512; path=/; expires=Wed, 09
+        Apr 2025 13:20:15 GMT; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - a2e58148-48d2-455c-a7c5-efe099308f88
+      X-Runtime:
+      - '0.048962'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/login?code=hVrDQCoou4KqtdBIdEN-wBNr2hbG_X_6FvWnYEZwR4dEdtde5JdtNopggrXNBFWlkdt6NK34sIGmuD5_IfJi1S5XHTMtYRcyMuAEGcg&state=%2Fs3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:17 GMT
+      SET-COOKIE:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTJMQ0pwWVhRaU9qRTNORFF4TVRnME1UWXNJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLmQwMmt4Qk41c3M2eUF4V2RmNS1Ra29Uc21ERDhFa0VOc2VveHVtdGRkdlJOWkRvWmRRZ2tSdXlQblBQUkNseDZnSERZeWxHbDRLRHVpZ1RYVkZsRWVNOEMxXzR4eHdNUzlkSFhYTHJESDdrTURsd0pTbHJYRUlNVWlRSHV0eXlGTzI3dXBJRTM2UU9aQzZnQl9KVWQ3TjFIejlOLTJPTTZvaDF2ZnhOLU5TUTlZYjltSHhRdHdzcG5VZ180Y0NycEJ5aHo4b3dhV290MTBpWFMwcEJzMEFSekZheHZyelV5bFpZNU9jQ09SM3JtOTdQdkZ1NnNldFY1dkxDeS1ScHUzWDFBVG5WOUE3ZDZTeUYyT0xoUW1Xb3pxVUdUa2txV0hmUE9zbFFjaHZubG9OajZmSlBTTDJzdFQ1MGZnTHotWkkyREpMbWpFeWN3M3VJeGtLcS00dyIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTYsImV4cCI6MTc0NDcyMzIxNn0.lv1HNqfMrj__bhvFuftwYJwVKEXEux-xIBRaNtnw50iwlYFgF4TKUrZxJzbfmlPs1FMW6v-Qt_PGO9hRtR2L79su1AkYYVE7lWczqn2jrOiiTCe8c-nTJZ9mHVKdNXZCA6T_rLnwjwLFTMi3raOzZguXmqANSCQT2z2gwWUJVDw2aZaj9nz0BDDVaDpXcZ06LOwsKi5XPeBR6zYVYpzeTVYAG4mb2Zdwc882c5_O6qe0zz1-QLk5PP14OWGhzELK9yEvR9BoaDEw4rk36hQMFEpQeZftP8pY2ekEjD0I_u40_nOij78F8gGxrFkDa5JA0vjjNBXo6xiR-e1_-59quJpkvFatBeXMAZythbpO3OBPYF327Juyil2fyeLwct9oGfE__GfBVfQRPUDJq48f3t1n9nNbr-kjGMHFBL6BrNx0FjdvL4AQKLi-WAQ8x0r2Vm5bya4knXrvO-yBR6QGHuLbv9cotGo5X3QBa8XfRPJ4vqY9sTOKwj9LW-T1qKB7Kc4X-KoqEeHAQSt3waLhPFWK9pMe9cS2gOgXCZmZdRRVrrKjvGI4pLpKtjpSZZIo_ZtgnmiPr-MQec-DrgQw9cRg2fjIpqjVK9Uj7jUWGofs3vq0vwjmKMD-EWstHrZaZB3X9v_XJD46rlZREON41exTRmQZ8n_O949ESh19dgw;
+        Expires=Tue, 15 Apr 2025 13:20:16 GMT; Path=/; Domain=.asf.alaska.edu
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTJMQ0pwWVhRaU9qRTNORFF4TVRnME1UWXNJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLmQwMmt4Qk41c3M2eUF4V2RmNS1Ra29Uc21ERDhFa0VOc2VveHVtdGRkdlJOWkRvWmRRZ2tSdXlQblBQUkNseDZnSERZeWxHbDRLRHVpZ1RYVkZsRWVNOEMxXzR4eHdNUzlkSFhYTHJESDdrTURsd0pTbHJYRUlNVWlRSHV0eXlGTzI3dXBJRTM2UU9aQzZnQl9KVWQ3TjFIejlOLTJPTTZvaDF2ZnhOLU5TUTlZYjltSHhRdHdzcG5VZ180Y0NycEJ5aHo4b3dhV290MTBpWFMwcEJzMEFSekZheHZyelV5bFpZNU9jQ09SM3JtOTdQdkZ1NnNldFY1dkxDeS1ScHUzWDFBVG5WOUE3ZDZTeUYyT0xoUW1Xb3pxVUdUa2txV0hmUE9zbFFjaHZubG9OajZmSlBTTDJzdFQ1MGZnTHotWkkyREpMbWpFeWN3M3VJeGtLcS00dyIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTYsImV4cCI6MTc0NDcyMzIxNn0.lv1HNqfMrj__bhvFuftwYJwVKEXEux-xIBRaNtnw50iwlYFgF4TKUrZxJzbfmlPs1FMW6v-Qt_PGO9hRtR2L79su1AkYYVE7lWczqn2jrOiiTCe8c-nTJZ9mHVKdNXZCA6T_rLnwjwLFTMi3raOzZguXmqANSCQT2z2gwWUJVDw2aZaj9nz0BDDVaDpXcZ06LOwsKi5XPeBR6zYVYpzeTVYAG4mb2Zdwc882c5_O6qe0zz1-QLk5PP14OWGhzELK9yEvR9BoaDEw4rk36hQMFEpQeZftP8pY2ekEjD0I_u40_nOij78F8gGxrFkDa5JA0vjjNBXo6xiR-e1_-59quJpkvFatBeXMAZythbpO3OBPYF327Juyil2fyeLwct9oGfE__GfBVfQRPUDJq48f3t1n9nNbr-kjGMHFBL6BrNx0FjdvL4AQKLi-WAQ8x0r2Vm5bya4knXrvO-yBR6QGHuLbv9cotGo5X3QBa8XfRPJ4vqY9sTOKwj9LW-T1qKB7Kc4X-KoqEeHAQSt3waLhPFWK9pMe9cS2gOgXCZmZdRRVrrKjvGI4pLpKtjpSZZIo_ZtgnmiPr-MQec-DrgQw9cRg2fjIpqjVK9Uj7jUWGofs3vq0vwjmKMD-EWstHrZaZB3X9v_XJD46rlZREON41exTRmQZ8n_O949ESh19dgw;
+        Expires=Tue, 15 Apr 2025 13:20:16 GMT; Path=/; Domain=.asf.alaska.edu
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 bebfdaf3481b8e276dc3fc8a17fefd66.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - aug5MlhIfQu8-Sof-ilz6eKCN0soPZ2s-dE7gVocE7piknBIJcuA8A==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f5228f-3633757239526d7314b8bd5e;Parent=088ba710ff8f5d38;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - /s3credentials
+      x-amz-apigw-id:
+      - ItJWjFtUvHcEQNg=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:17 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.237
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 21948516-ecf2-4c71-bef3-6368f5fbfd2d
+      x-amzn-RequestId:
+      - 0f3a62b0-dc65-4a51-90d8-aa03929b304b
+      x-request-id:
+      - 658cf24f-d5b2-45ec-a357-f43d841cca14
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Cookie:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTJMQ0pwWVhRaU9qRTNORFF4TVRnME1UWXNJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLmQwMmt4Qk41c3M2eUF4V2RmNS1Ra29Uc21ERDhFa0VOc2VveHVtdGRkdlJOWkRvWmRRZ2tSdXlQblBQUkNseDZnSERZeWxHbDRLRHVpZ1RYVkZsRWVNOEMxXzR4eHdNUzlkSFhYTHJESDdrTURsd0pTbHJYRUlNVWlRSHV0eXlGTzI3dXBJRTM2UU9aQzZnQl9KVWQ3TjFIejlOLTJPTTZvaDF2ZnhOLU5TUTlZYjltSHhRdHdzcG5VZ180Y0NycEJ5aHo4b3dhV290MTBpWFMwcEJzMEFSekZheHZyelV5bFpZNU9jQ09SM3JtOTdQdkZ1NnNldFY1dkxDeS1ScHUzWDFBVG5WOUE3ZDZTeUYyT0xoUW1Xb3pxVUdUa2txV0hmUE9zbFFjaHZubG9OajZmSlBTTDJzdFQ1MGZnTHotWkkyREpMbWpFeWN3M3VJeGtLcS00dyIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTYsImV4cCI6MTc0NDcyMzIxNn0.lv1HNqfMrj__bhvFuftwYJwVKEXEux-xIBRaNtnw50iwlYFgF4TKUrZxJzbfmlPs1FMW6v-Qt_PGO9hRtR2L79su1AkYYVE7lWczqn2jrOiiTCe8c-nTJZ9mHVKdNXZCA6T_rLnwjwLFTMi3raOzZguXmqANSCQT2z2gwWUJVDw2aZaj9nz0BDDVaDpXcZ06LOwsKi5XPeBR6zYVYpzeTVYAG4mb2Zdwc882c5_O6qe0zz1-QLk5PP14OWGhzELK9yEvR9BoaDEw4rk36hQMFEpQeZftP8pY2ekEjD0I_u40_nOij78F8gGxrFkDa5JA0vjjNBXo6xiR-e1_-59quJpkvFatBeXMAZythbpO3OBPYF327Juyil2fyeLwct9oGfE__GfBVfQRPUDJq48f3t1n9nNbr-kjGMHFBL6BrNx0FjdvL4AQKLi-WAQ8x0r2Vm5bya4knXrvO-yBR6QGHuLbv9cotGo5X3QBa8XfRPJ4vqY9sTOKwj9LW-T1qKB7Kc4X-KoqEeHAQSt3waLhPFWK9pMe9cS2gOgXCZmZdRRVrrKjvGI4pLpKtjpSZZIo_ZtgnmiPr-MQec-DrgQw9cRg2fjIpqjVK9Uj7jUWGofs3vq0vwjmKMD-EWstHrZaZB3X9v_XJD46rlZREON41exTRmQZ8n_O949ESh19dgw
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: '{"accessKeyId": "FAKEACCESS", "secretAccessKey": "FAKESECRET",
+        "sessionToken": "FAKESESSION",
+        "expiration": "2025-04-08 14:20:17+00:00"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '989'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:17 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 bebfdaf3481b8e276dc3fc8a17fefd66.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - VaiuvVALa7vnkDHPbDJ7kQpvJiyzY93fgLRWQuJt4wSlNVwf-YUZ9w==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f52291-229f9f3b27aef68b724dfe8f;Parent=0a2ca5f6bb3f283d;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-apigw-id:
+      - ItJW2FX1vHcEqXQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '989'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:17 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.209
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 84a4e0ac-1fa9-4193-a3ac-091b05562a7b
+      x-amzn-RequestId:
+      - f84d1c6d-cd99-4029-a401-9960fbf379bb
+      x-request-id:
+      - 4a7116b1-1b4a-4e50-9021-2be03ab913e6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:18 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 97713e58966a50f0173f1cdb4e67aea0.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 0fn5UAjjzJ8NSIuJjyGuVNWOt_WNTO9i_QpcK059IKhNEp0BPKvFIg==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f52292-38936c7825cef79415a6436c;Parent=45cf21cf62be3701;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://cumulus.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+      x-amz-apigw-id:
+      - ItJW7GQ6PHcEH5w=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:18 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.207
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 59517fd8-404f-4ab9-967c-a2e287e9e6ee
+      x-amzn-RequestId:
+      - b3ee5f04-fa90-4eb4-ba6b-c1557aa81aa5
+      x-request-id:
+      - c0879a89-960e-4c7e-859b-c0756ae3d714
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Authorization:
+      - Basic c2NvdHQuc3RhbmllOlE1TnU0I0xxdHIzbQ==
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://urs.earthdata.nasa.gov/oauth/authorize?client_id=BO_n7nTIlMljdvU6kRRB3g&response_type=code&redirect_uri=https://cumulus.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+  response:
+    body:
+      string: You are being redirected to https://cumulus.asf.alaska.edu/login?code=8VUL_mNB8bAG312xZ8LYFoPFj7XjK5uok6XXlYH9CQk2oBhCnnB1TDagENMvkP2iGxnLZGcqIIb-pSt03SVmBaLdxHMGS-s4CE4cLa0&state=%2Fs3credentials
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Origin:
+      - 'null'
+      Access-Control-Expose-Headers:
+      - 'true'
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 08 Apr 2025 13:20:18 GMT
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Location:
+      - https://cumulus.asf.alaska.edu/login?code=8VUL_mNB8bAG312xZ8LYFoPFj7XjK5uok6XXlYH9CQk2oBhCnnB1TDagENMvkP2iGxnLZGcqIIb-pSt03SVmBaLdxHMGS-s4CE4cLa0&state=%2Fs3credentials
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Set-Cookie:
+      - urs_user_already_logged=yes; domain=earthdata.nasa.gov; path=/; expires=Wed,
+        09 Apr 2025 13:20:18 GMT; secure; HttpOnly; SameSite=Lax
+      - _urs-gui_session=b43c9236a090bd6ae05dac2ff05ee75f; path=/; expires=Wed, 09
+        Apr 2025 13:20:18 GMT; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - ee09b9e8-e684-4f68-be16-07442c9c5af8
+      X-Runtime:
+      - '0.060433'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/login?code=8VUL_mNB8bAG312xZ8LYFoPFj7XjK5uok6XXlYH9CQk2oBhCnnB1TDagENMvkP2iGxnLZGcqIIb-pSt03SVmBaLdxHMGS-s4CE4cLa0&state=%2Fs3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:20 GMT
+      SET-COOKIE:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTVMQ0pwWVhRaU9qRTNORFF4TVRnME1Ua3NJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLlJmdkdEcGlZTkhZYUNESGUwSXhmVzlsQk54WUNwaFJ4MzVaRXZ1MWZiMWVhY1FJMWp0SG82d3V2S0g2WFRyWXZmUTZqRUVnX1pmZHJ3bTFNTlRGdkotZ29nUHFGb1hxQzU0OUFfNjVMQVlOeGZERGc3YXpIUDRMVHFCWkpLM3lJeHM0clZ1UGpiOG5LMDA5anZjaUNOM0JOQjRoV2l4SzFkVkwzd29XOUltSG1uSWtLdk1iZWpOa0hHdkJlTE1rS05YMVFKa3N4VE9CYkY3QnNqQ0RsTWhvb3N5Y0ZmYlRuamFBZ2ZXWkh1cF8weUFhM01UUXpjbW05dl90MWJ1VXJUU0xpOGFQUEphcTJPLUJsQkhDNDItOWVkNU1wVlhBREhEZjdNYXZsTktuSlg1TEcwSVdzNzkwOFBYZEJyM1BtOFJPbkdZcUpXN2hybW1IUWJEbVVMUSIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTksImV4cCI6MTc0NDcyMzIxOX0.XC0vpp307EAp-U7rgv439c3nEMeazd-EzfbkM8bih8oysOlt8lPFXZ8sLdh0ObZcvgGGc5cBkeXY6ckRjiglMNj2x009NI4PGoaAGxLvq6AHD8TAoQr40cvMi1rMHNUrK5C_3tc7kW_jRi0aYMUHBobEpcGcdfNvKMe6Kh88nseH4wxu0Qr73_w7De1kIAxQmFkg1WUpjuc8c2zZWy5dugOU-DMQbub2e-wYoGaFQE99l0j7AU6heDtB3OORdL7aR_HkJfrPrXXl9MDyd8XWX4eZNaoB4p2kbvACGnDI3mkcd0V2b8eygs1CyYIUr6AJ7iJnbetYpnynhgdZUrx2TmnYF3tq48vQskwo--xn4S-PSkaO5noSj3GXuCUGzHSHtBa7l4zdmyzwSLpk8tPuxZ_aTFfVIRc2Nwt1YC7wHHbeSYrRqPpvCOcgEyNivjjB3Bs8GpiLMn4L838uNIj1dXV4QAm-1ORT0G1CJYmKngvGeE_17hY9yZGcJrePTzrUEauTiwYQ46uExhQFGtz0wXYYUH-zddu4plG29-u6m1WrPpJUDm-SsZ5jybSG-vGyuDFaokivhyMuJOG-r8p1ZWF9nbPD2FUBwF2VgpCYXCncps2iFdHt2_weUmWeAKsr0vgNZnPWW5YZReVwF_X1eVmzS8OSuumBTdM3ObQOo_o;
+        Expires=Tue, 15 Apr 2025 13:20:19 GMT; Path=/; Domain=.asf.alaska.edu
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTVMQ0pwWVhRaU9qRTNORFF4TVRnME1Ua3NJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLlJmdkdEcGlZTkhZYUNESGUwSXhmVzlsQk54WUNwaFJ4MzVaRXZ1MWZiMWVhY1FJMWp0SG82d3V2S0g2WFRyWXZmUTZqRUVnX1pmZHJ3bTFNTlRGdkotZ29nUHFGb1hxQzU0OUFfNjVMQVlOeGZERGc3YXpIUDRMVHFCWkpLM3lJeHM0clZ1UGpiOG5LMDA5anZjaUNOM0JOQjRoV2l4SzFkVkwzd29XOUltSG1uSWtLdk1iZWpOa0hHdkJlTE1rS05YMVFKa3N4VE9CYkY3QnNqQ0RsTWhvb3N5Y0ZmYlRuamFBZ2ZXWkh1cF8weUFhM01UUXpjbW05dl90MWJ1VXJUU0xpOGFQUEphcTJPLUJsQkhDNDItOWVkNU1wVlhBREhEZjdNYXZsTktuSlg1TEcwSVdzNzkwOFBYZEJyM1BtOFJPbkdZcUpXN2hybW1IUWJEbVVMUSIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTksImV4cCI6MTc0NDcyMzIxOX0.XC0vpp307EAp-U7rgv439c3nEMeazd-EzfbkM8bih8oysOlt8lPFXZ8sLdh0ObZcvgGGc5cBkeXY6ckRjiglMNj2x009NI4PGoaAGxLvq6AHD8TAoQr40cvMi1rMHNUrK5C_3tc7kW_jRi0aYMUHBobEpcGcdfNvKMe6Kh88nseH4wxu0Qr73_w7De1kIAxQmFkg1WUpjuc8c2zZWy5dugOU-DMQbub2e-wYoGaFQE99l0j7AU6heDtB3OORdL7aR_HkJfrPrXXl9MDyd8XWX4eZNaoB4p2kbvACGnDI3mkcd0V2b8eygs1CyYIUr6AJ7iJnbetYpnynhgdZUrx2TmnYF3tq48vQskwo--xn4S-PSkaO5noSj3GXuCUGzHSHtBa7l4zdmyzwSLpk8tPuxZ_aTFfVIRc2Nwt1YC7wHHbeSYrRqPpvCOcgEyNivjjB3Bs8GpiLMn4L838uNIj1dXV4QAm-1ORT0G1CJYmKngvGeE_17hY9yZGcJrePTzrUEauTiwYQ46uExhQFGtz0wXYYUH-zddu4plG29-u6m1WrPpJUDm-SsZ5jybSG-vGyuDFaokivhyMuJOG-r8p1ZWF9nbPD2FUBwF2VgpCYXCncps2iFdHt2_weUmWeAKsr0vgNZnPWW5YZReVwF_X1eVmzS8OSuumBTdM3ObQOo_o;
+        Expires=Tue, 15 Apr 2025 13:20:19 GMT; Path=/; Domain=.asf.alaska.edu
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 8f8f56e20a7e26014a52398627840a50.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - obWQIWS7M8kW3jAFnzwsZLitavCQbVMvWw-d0pEsPsEBclKJT8mGsA==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f52292-50ea29ac1cafefad08c64974;Parent=20deb2836a621ade;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - /s3credentials
+      x-amz-apigw-id:
+      - ItJXBGZyvHcEntQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:20 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.201
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 062f4ecd-af06-4ab8-8157-22c7c61d740d
+      x-amzn-RequestId:
+      - a8f47a68-0101-4653-a398-8a56a5cf3b3b
+      x-request-id:
+      - 633b542b-9e99-4772-a409-878a7d0dc852
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Cookie:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0LnN0YW5pZUB1dGV4YXMuZWR1IiwidXJzLWFjY2Vzcy10b2tlbiI6ImV5SjBlWEFpT2lKS1YxUWlMQ0p2Y21sbmFXNGlPaUpGWVhKMGFHUmhkR0VnVEc5bmFXNGlMQ0p6YVdjaU9pSmxaR3hxZDNSd2RXSnJaWGxmYjNCeklpd2lZV3huSWpvaVVsTXlOVFlpZlEuZXlKMGVYQmxJam9pVDBGMWRHZ2lMQ0pqYkdsbGJuUmZhV1FpT2lKQ1QxOXVOMjVVU1d4TmJHcGtkbFUyYTFKU1FqTm5JaXdpWlhod0lqb3hOelEyTnpFd05ERTVMQ0pwWVhRaU9qRTNORFF4TVRnME1Ua3NJbWx6Y3lJNkltaDBkSEJ6T2k4dmRYSnpMbVZoY25Sb1pHRjBZUzV1WVhOaExtZHZkaUlzSW5WcFpDSTZJbk5qYjNSMExuTjBZVzVwWlNJc0ltbGtaVzUwYVhSNVgzQnliM1pwWkdWeUlqb2laV1JzWDI5d2N5SXNJbUZ6YzNWeVlXNWpaVjlzWlhabGJDSTZNeXdpWVdOeUlqb2laV1JzSW4wLlJmdkdEcGlZTkhZYUNESGUwSXhmVzlsQk54WUNwaFJ4MzVaRXZ1MWZiMWVhY1FJMWp0SG82d3V2S0g2WFRyWXZmUTZqRUVnX1pmZHJ3bTFNTlRGdkotZ29nUHFGb1hxQzU0OUFfNjVMQVlOeGZERGc3YXpIUDRMVHFCWkpLM3lJeHM0clZ1UGpiOG5LMDA5anZjaUNOM0JOQjRoV2l4SzFkVkwzd29XOUltSG1uSWtLdk1iZWpOa0hHdkJlTE1rS05YMVFKa3N4VE9CYkY3QnNqQ0RsTWhvb3N5Y0ZmYlRuamFBZ2ZXWkh1cF8weUFhM01UUXpjbW05dl90MWJ1VXJUU0xpOGFQUEphcTJPLUJsQkhDNDItOWVkNU1wVlhBREhEZjdNYXZsTktuSlg1TEcwSVdzNzkwOFBYZEJyM1BtOFJPbkdZcUpXN2hybW1IUWJEbVVMUSIsInVycy1ncm91cHMiOltdLCJpYXQiOjE3NDQxMTg0MTksImV4cCI6MTc0NDcyMzIxOX0.XC0vpp307EAp-U7rgv439c3nEMeazd-EzfbkM8bih8oysOlt8lPFXZ8sLdh0ObZcvgGGc5cBkeXY6ckRjiglMNj2x009NI4PGoaAGxLvq6AHD8TAoQr40cvMi1rMHNUrK5C_3tc7kW_jRi0aYMUHBobEpcGcdfNvKMe6Kh88nseH4wxu0Qr73_w7De1kIAxQmFkg1WUpjuc8c2zZWy5dugOU-DMQbub2e-wYoGaFQE99l0j7AU6heDtB3OORdL7aR_HkJfrPrXXl9MDyd8XWX4eZNaoB4p2kbvACGnDI3mkcd0V2b8eygs1CyYIUr6AJ7iJnbetYpnynhgdZUrx2TmnYF3tq48vQskwo--xn4S-PSkaO5noSj3GXuCUGzHSHtBa7l4zdmyzwSLpk8tPuxZ_aTFfVIRc2Nwt1YC7wHHbeSYrRqPpvCOcgEyNivjjB3Bs8GpiLMn4L838uNIj1dXV4QAm-1ORT0G1CJYmKngvGeE_17hY9yZGcJrePTzrUEauTiwYQ46uExhQFGtz0wXYYUH-zddu4plG29-u6m1WrPpJUDm-SsZ5jybSG-vGyuDFaokivhyMuJOG-r8p1ZWF9nbPD2FUBwF2VgpCYXCncps2iFdHt2_weUmWeAKsr0vgNZnPWW5YZReVwF_X1eVmzS8OSuumBTdM3ObQOo_o
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: '{"accessKeyId": "FAKEACCESS", "secretAccessKey": "FAKESECRET",
+        "sessionToken": "FAKESESSION",
+        "expiration": "2025-04-08 14:20:21+00:00"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '989'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:20:21 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 722941ea5f2183d4a12262e95ff19d7a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 8yw4jZpDJ12vWGJbcmvq92ifvuib2ax_ERjQrENM12h9x55QuNL8uw==
+      X-Amz-Cf-Pop:
+      - JFK52-P8
+      X-Amzn-Trace-Id:
+      - Root=1-67f52294-1a38265f26b083b161ff7765;Parent=648a02b811c54a87;Sampled=0;Lineage=1:c58da59d:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-apigw-id:
+      - ItJXVH2EPHcEBFQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '989'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:20:21 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 3.172.0.239
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 57d62623-0ac3-4fc9-aef1-44d937efa11b
+      x-amzn-RequestId:
+      - 91798d7a-666c-496f-a370-f90fca718c05
+      x-request-id:
+      - e0ceca74-f2a1-4241-be36-317643dd9c65
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_credentials/test_get_temporary_aws_credentials_different_endpoint.yaml
+++ b/tests/cassettes/test_credentials/test_get_temporary_aws_credentials_different_endpoint.yaml
@@ -1,0 +1,280 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus-test.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:22:31 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 bf49d89d8a3c52a5998a7b465717a00e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - XQX0SVfabcZrvrhEPloz-tRFtO_hY0dFlKmmYkugVn5BRoLREwHGcg==
+      X-Amz-Cf-Pop:
+      - EWR53-P1
+      X-Amzn-Trace-Id:
+      - Root=1-67f52317-6a711aa54304a5912d89dc3f;Parent=226b12416047863b;Sampled=0;Lineage=1:c2a07d4a:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - https://uat.urs.earthdata.nasa.gov/oauth/authorize?client_id=LqWhtVpLmwaD4VqHeoN7ww&response_type=code&redirect_uri=https://cumulus-test.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+      x-amz-apigw-id:
+      - ItJrsFOPPHcEexQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:22:31 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 130.176.166.38
+      x-amzn-Remapped-x-amzn-RequestId:
+      - e0336501-6ebb-4c9b-bfa6-d681f7c12574
+      x-amzn-RequestId:
+      - 22f76531-50be-4c72-b26a-d3b089e1572c
+      x-request-id:
+      - 9870e5ce-d93d-4b84-9e62-69b928187ac1
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Authorization:
+      - Basic c2NvdHQuc3RhbmllOlE1TnU0I0xxdHIzbQ==
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://uat.urs.earthdata.nasa.gov/oauth/authorize?client_id=LqWhtVpLmwaD4VqHeoN7ww&response_type=code&redirect_uri=https://cumulus-test.asf.alaska.edu/login&state=%2Fs3credentials&app_type=401
+  response:
+    body:
+      string: You are being redirected to https://cumulus-test.asf.alaska.edu/login?code=i5hTtSOpi04N6NBLvdGTzUncfkLkn3ShZJj7DLt-Ja54Mkt0PHx726svSjsF9tSMZHtvnMOUmHsLDB-D8z_y-ZZ5Wu-7gIOs2tN_0qFu55DIxQ&state=%2Fs3credentials
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+      Access-Control-Allow-Origin:
+      - 'null'
+      Access-Control-Expose-Headers:
+      - 'true'
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 08 Apr 2025 13:22:31 GMT
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Location:
+      - https://cumulus-test.asf.alaska.edu/login?code=i5hTtSOpi04N6NBLvdGTzUncfkLkn3ShZJj7DLt-Ja54Mkt0PHx726svSjsF9tSMZHtvnMOUmHsLDB-D8z_y-ZZ5Wu-7gIOs2tN_0qFu55DIxQ&state=%2Fs3credentials
+      Pragma:
+      - no-cache
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - nginx/1.22.1
+      Set-Cookie:
+      - uat_urs_user_already_logged=yes; domain=earthdata.nasa.gov; path=/; expires=Wed,
+        09 Apr 2025 13:22:31 GMT; secure; HttpOnly; SameSite=Lax
+      - _urs_uat-gui_session=f40b289e8ff512cc6b19a4d74a9fa4f0; path=/; expires=Wed,
+        09 Apr 2025 13:22:31 GMT; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Request-Id:
+      - eaf27b18-492f-4e33-95a4-a5409a13eeb4
+      X-Runtime:
+      - '0.034507'
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus-test.asf.alaska.edu/login?code=i5hTtSOpi04N6NBLvdGTzUncfkLkn3ShZJj7DLt-Ja54Mkt0PHx726svSjsF9tSMZHtvnMOUmHsLDB-D8z_y-ZZ5Wu-7gIOs2tN_0qFu55DIxQ&state=%2Fs3credentials
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:22:33 GMT
+      SET-COOKIE:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0Lmouc3Rhbmlld2ljekBqcGwubmFzYS5nb3YiLCJ1cnMtYWNjZXNzLXRva2VuIjoiZXlKMGVYQWlPaUpLVjFRaUxDSnZjbWxuYVc0aU9pSkZZWEowYUdSaGRHRWdURzluYVc0aUxDSnphV2NpT2lKbFpHeHFkM1J3ZFdKclpYbGZkV0YwSWl3aVlXeG5Jam9pVWxNeU5UWWlmUS5leUowZVhCbElqb2lUMEYxZEdnaUxDSmpiR2xsYm5SZmFXUWlPaUpNY1Zkb2RGWndURzEzWVVRMFZuRklaVzlPTjNkM0lpd2laWGh3SWpveE56UTJOekV3TlRVeUxDSnBZWFFpT2pFM05EUXhNVGcxTlRJc0ltbHpjeUk2SW1oMGRIQnpPaTh2ZFdGMExuVnljeTVsWVhKMGFHUmhkR0V1Ym1GellTNW5iM1lpTENKMWFXUWlPaUp6WTI5MGRDNXpkR0Z1YVdVaUxDSnBaR1Z1ZEdsMGVWOXdjbTkyYVdSbGNpSTZJbVZrYkY5MVlYUWlMQ0poYzNOMWNtRnVZMlZmYkdWMlpXd2lPak1zSW1GamNpSTZJbVZrYkNKOS5Da2w0MTlQaG44RlZVaG9HZkl6NExwcWY0N1oyWjd4TFVGRTAzcVl2XzBPMHhDOVYxVFFCMGJ0dTlUa3FsU2hrZE5XdnAtaW45eTBZYUJiNEZSRXl5NTBKVEZiMDUwc08wTnJNVXR5NmM3Xy0wOTdEN2ROeng5ZU1UYTRvbENkeFV2Rk9mSThCbUNJb2NCZHhXeTZadFg4VVdwRGUwUzJ2ajdDRG5YMXBFQVpacVFUREltblFJY2N1MFIzZGlRYjFxSXh6d0JJYTVpekVCM240UWZZQ1JmeHB0REVxa0FCeE9JeG42MG41VmhvZExxVUQ1cE9UTDl1V0FRWlJDX2dMZUt5VkRpRTEtRFRFdVJzS0NCWGZuVEFOaVktVklDYUNYdFhoZ2w1UmtQSE1naEhqMVBlWmltZzJmMlItUlUwenk4TDRXNmZpNjNzMV9QU1Y0blVRcHciLCJ1cnMtZ3JvdXBzIjpbeyJncm91cF9pZCI6IjFjN2RkNTlhLTVkYTctNDdlOS1hZjViLTJhNmViYTdkMGQzZSIsIm5hbWUiOiJwcmUtbGF1bmNoLWRhdGEtYWNjZXNzIiwidGFnIjpudWxsLCJzaGFyZWRfdXNlcl9ncm91cCI6ZmFsc2UsImNyZWF0ZWRfYnkiOiJzaXJjLmN1bXVsdXMiLCJhcHBfdWlkIjoic2lyYy5jdW11bHVzIiwiY2xpZW50X2lkIjoiTHFXaHRWcExtd2FENFZxSGVvTjd3dyJ9XSwiaWF0IjoxNzQ0MTE4NTUyLCJleHAiOjE3NDQ3MjMzNTJ9.RoqXlu5-nhkOibMczZIx5Evx1T6VebXBoJDne_VjlGSh_5BY6dFdK1VSE-aItS89mCBFK0GziSgxn6Vju3BPfFdtwDhYC0_V9XGFpl7eh-ZPgbqWg4PzexVG3k5ZAxvkpZ9rpICwIEXU3BfD7X8YOoSSeHRnVQ42GLuxVCkEbVEqkYuwv2GAfH3t-PGFZOwVLB5XRnltwrU273D0V8t9NzcUcKwBthE_otuw1xNI6xWJCMS2V9zU0Cp_S1Vv72-LVQOjyfZiRxswffoRr8oz8jRaIc3iIsLadKVroTxw4r4OoMEuYIkiXFCiV47GAifZGa2igsOFnq_nPO1Eyeuu2dBxxZOljsKB6UJWHoo_eC23eanSsyBlJAM0gtiNegPYaoQS3axDtCEJqMExKeZCQvsai08IeQTHV17Ahd4VZOG-rKlEPTLkUvfYVJsbORDxkWfIksJEumrXGcnlUnTNLkmeWUgo8tvXwzmtRnMCa6waogD9PzpDYn7yiccOLKRc-krhtA_DMxzNlbWVQB1VBa36vA-WW-A1p7HlApIxKFrn0QS34LuN5j4o6guYUldduWvzeopBl7qb0UYXNfrLNyPBzaUtMKj6ddBpy9A3ArCBzjcpzx9Wsr1NFGKUNTLvEn-B4oQY2EFGnTIo5PuDMJum3fU05vDIMazbs7EslK4;
+        Expires=Tue, 15 Apr 2025 13:22:32 GMT; Path=/; Domain=.asf.alaska.edu
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0Lmouc3Rhbmlld2ljekBqcGwubmFzYS5nb3YiLCJ1cnMtYWNjZXNzLXRva2VuIjoiZXlKMGVYQWlPaUpLVjFRaUxDSnZjbWxuYVc0aU9pSkZZWEowYUdSaGRHRWdURzluYVc0aUxDSnphV2NpT2lKbFpHeHFkM1J3ZFdKclpYbGZkV0YwSWl3aVlXeG5Jam9pVWxNeU5UWWlmUS5leUowZVhCbElqb2lUMEYxZEdnaUxDSmpiR2xsYm5SZmFXUWlPaUpNY1Zkb2RGWndURzEzWVVRMFZuRklaVzlPTjNkM0lpd2laWGh3SWpveE56UTJOekV3TlRVeUxDSnBZWFFpT2pFM05EUXhNVGcxTlRJc0ltbHpjeUk2SW1oMGRIQnpPaTh2ZFdGMExuVnljeTVsWVhKMGFHUmhkR0V1Ym1GellTNW5iM1lpTENKMWFXUWlPaUp6WTI5MGRDNXpkR0Z1YVdVaUxDSnBaR1Z1ZEdsMGVWOXdjbTkyYVdSbGNpSTZJbVZrYkY5MVlYUWlMQ0poYzNOMWNtRnVZMlZmYkdWMlpXd2lPak1zSW1GamNpSTZJbVZrYkNKOS5Da2w0MTlQaG44RlZVaG9HZkl6NExwcWY0N1oyWjd4TFVGRTAzcVl2XzBPMHhDOVYxVFFCMGJ0dTlUa3FsU2hrZE5XdnAtaW45eTBZYUJiNEZSRXl5NTBKVEZiMDUwc08wTnJNVXR5NmM3Xy0wOTdEN2ROeng5ZU1UYTRvbENkeFV2Rk9mSThCbUNJb2NCZHhXeTZadFg4VVdwRGUwUzJ2ajdDRG5YMXBFQVpacVFUREltblFJY2N1MFIzZGlRYjFxSXh6d0JJYTVpekVCM240UWZZQ1JmeHB0REVxa0FCeE9JeG42MG41VmhvZExxVUQ1cE9UTDl1V0FRWlJDX2dMZUt5VkRpRTEtRFRFdVJzS0NCWGZuVEFOaVktVklDYUNYdFhoZ2w1UmtQSE1naEhqMVBlWmltZzJmMlItUlUwenk4TDRXNmZpNjNzMV9QU1Y0blVRcHciLCJ1cnMtZ3JvdXBzIjpbeyJncm91cF9pZCI6IjFjN2RkNTlhLTVkYTctNDdlOS1hZjViLTJhNmViYTdkMGQzZSIsIm5hbWUiOiJwcmUtbGF1bmNoLWRhdGEtYWNjZXNzIiwidGFnIjpudWxsLCJzaGFyZWRfdXNlcl9ncm91cCI6ZmFsc2UsImNyZWF0ZWRfYnkiOiJzaXJjLmN1bXVsdXMiLCJhcHBfdWlkIjoic2lyYy5jdW11bHVzIiwiY2xpZW50X2lkIjoiTHFXaHRWcExtd2FENFZxSGVvTjd3dyJ9XSwiaWF0IjoxNzQ0MTE4NTUyLCJleHAiOjE3NDQ3MjMzNTJ9.RoqXlu5-nhkOibMczZIx5Evx1T6VebXBoJDne_VjlGSh_5BY6dFdK1VSE-aItS89mCBFK0GziSgxn6Vju3BPfFdtwDhYC0_V9XGFpl7eh-ZPgbqWg4PzexVG3k5ZAxvkpZ9rpICwIEXU3BfD7X8YOoSSeHRnVQ42GLuxVCkEbVEqkYuwv2GAfH3t-PGFZOwVLB5XRnltwrU273D0V8t9NzcUcKwBthE_otuw1xNI6xWJCMS2V9zU0Cp_S1Vv72-LVQOjyfZiRxswffoRr8oz8jRaIc3iIsLadKVroTxw4r4OoMEuYIkiXFCiV47GAifZGa2igsOFnq_nPO1Eyeuu2dBxxZOljsKB6UJWHoo_eC23eanSsyBlJAM0gtiNegPYaoQS3axDtCEJqMExKeZCQvsai08IeQTHV17Ahd4VZOG-rKlEPTLkUvfYVJsbORDxkWfIksJEumrXGcnlUnTNLkmeWUgo8tvXwzmtRnMCa6waogD9PzpDYn7yiccOLKRc-krhtA_DMxzNlbWVQB1VBa36vA-WW-A1p7HlApIxKFrn0QS34LuN5j4o6guYUldduWvzeopBl7qb0UYXNfrLNyPBzaUtMKj6ddBpy9A3ArCBzjcpzx9Wsr1NFGKUNTLvEn-B4oQY2EFGnTIo5PuDMJum3fU05vDIMazbs7EslK4;
+        Expires=Tue, 15 Apr 2025 13:22:32 GMT; Path=/; Domain=.asf.alaska.edu
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Via:
+      - 1.1 3f65d34f6010e326e59d2f311de6e202.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 4ouP5jYsUT_qMX6hpvyiDiG-Q8gnovIb2QaiBqkI0t8HRVuqAZ5jKA==
+      X-Amz-Cf-Pop:
+      - EWR53-P1
+      X-Amzn-Trace-Id:
+      - Root=1-67f52317-6cdadb2c580abb615429cb0a;Parent=1f31da90341bc1f5;Sampled=0;Lineage=1:c2a07d4a:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      location:
+      - /s3credentials
+      x-amz-apigw-id:
+      - ItJrxFt3PHcEpkQ=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '0'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:22:33 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 130.176.166.39
+      x-amzn-Remapped-x-amzn-RequestId:
+      - c9c33c1d-684e-4939-95c1-2ac699d9dce9
+      x-amzn-RequestId:
+      - de168916-fb54-4462-93ca-2b3cd6558610
+      x-request-id:
+      - d495922d-11e6-4389-ba47-e70de156164b
+    status:
+      code: 301
+      message: Moved Permanently
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Cookie:
+      - asf-urs=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cnMtdXNlci1pZCI6InNjb3R0LnN0YW5pZSIsImZpcnN0X25hbWUiOiJTY290dCIsImxhc3RfbmFtZSI6IlN0YW5pZXdpY3oiLCJlbWFpbCI6InNjb3R0Lmouc3Rhbmlld2ljekBqcGwubmFzYS5nb3YiLCJ1cnMtYWNjZXNzLXRva2VuIjoiZXlKMGVYQWlPaUpLVjFRaUxDSnZjbWxuYVc0aU9pSkZZWEowYUdSaGRHRWdURzluYVc0aUxDSnphV2NpT2lKbFpHeHFkM1J3ZFdKclpYbGZkV0YwSWl3aVlXeG5Jam9pVWxNeU5UWWlmUS5leUowZVhCbElqb2lUMEYxZEdnaUxDSmpiR2xsYm5SZmFXUWlPaUpNY1Zkb2RGWndURzEzWVVRMFZuRklaVzlPTjNkM0lpd2laWGh3SWpveE56UTJOekV3TlRVeUxDSnBZWFFpT2pFM05EUXhNVGcxTlRJc0ltbHpjeUk2SW1oMGRIQnpPaTh2ZFdGMExuVnljeTVsWVhKMGFHUmhkR0V1Ym1GellTNW5iM1lpTENKMWFXUWlPaUp6WTI5MGRDNXpkR0Z1YVdVaUxDSnBaR1Z1ZEdsMGVWOXdjbTkyYVdSbGNpSTZJbVZrYkY5MVlYUWlMQ0poYzNOMWNtRnVZMlZmYkdWMlpXd2lPak1zSW1GamNpSTZJbVZrYkNKOS5Da2w0MTlQaG44RlZVaG9HZkl6NExwcWY0N1oyWjd4TFVGRTAzcVl2XzBPMHhDOVYxVFFCMGJ0dTlUa3FsU2hrZE5XdnAtaW45eTBZYUJiNEZSRXl5NTBKVEZiMDUwc08wTnJNVXR5NmM3Xy0wOTdEN2ROeng5ZU1UYTRvbENkeFV2Rk9mSThCbUNJb2NCZHhXeTZadFg4VVdwRGUwUzJ2ajdDRG5YMXBFQVpacVFUREltblFJY2N1MFIzZGlRYjFxSXh6d0JJYTVpekVCM240UWZZQ1JmeHB0REVxa0FCeE9JeG42MG41VmhvZExxVUQ1cE9UTDl1V0FRWlJDX2dMZUt5VkRpRTEtRFRFdVJzS0NCWGZuVEFOaVktVklDYUNYdFhoZ2w1UmtQSE1naEhqMVBlWmltZzJmMlItUlUwenk4TDRXNmZpNjNzMV9QU1Y0blVRcHciLCJ1cnMtZ3JvdXBzIjpbeyJncm91cF9pZCI6IjFjN2RkNTlhLTVkYTctNDdlOS1hZjViLTJhNmViYTdkMGQzZSIsIm5hbWUiOiJwcmUtbGF1bmNoLWRhdGEtYWNjZXNzIiwidGFnIjpudWxsLCJzaGFyZWRfdXNlcl9ncm91cCI6ZmFsc2UsImNyZWF0ZWRfYnkiOiJzaXJjLmN1bXVsdXMiLCJhcHBfdWlkIjoic2lyYy5jdW11bHVzIiwiY2xpZW50X2lkIjoiTHFXaHRWcExtd2FENFZxSGVvTjd3dyJ9XSwiaWF0IjoxNzQ0MTE4NTUyLCJleHAiOjE3NDQ3MjMzNTJ9.RoqXlu5-nhkOibMczZIx5Evx1T6VebXBoJDne_VjlGSh_5BY6dFdK1VSE-aItS89mCBFK0GziSgxn6Vju3BPfFdtwDhYC0_V9XGFpl7eh-ZPgbqWg4PzexVG3k5ZAxvkpZ9rpICwIEXU3BfD7X8YOoSSeHRnVQ42GLuxVCkEbVEqkYuwv2GAfH3t-PGFZOwVLB5XRnltwrU273D0V8t9NzcUcKwBthE_otuw1xNI6xWJCMS2V9zU0Cp_S1Vv72-LVQOjyfZiRxswffoRr8oz8jRaIc3iIsLadKVroTxw4r4OoMEuYIkiXFCiV47GAifZGa2igsOFnq_nPO1Eyeuu2dBxxZOljsKB6UJWHoo_eC23eanSsyBlJAM0gtiNegPYaoQS3axDtCEJqMExKeZCQvsai08IeQTHV17Ahd4VZOG-rKlEPTLkUvfYVJsbORDxkWfIksJEumrXGcnlUnTNLkmeWUgo8tvXwzmtRnMCa6waogD9PzpDYn7yiccOLKRc-krhtA_DMxzNlbWVQB1VBa36vA-WW-A1p7HlApIxKFrn0QS34LuN5j4o6guYUldduWvzeopBl7qb0UYXNfrLNyPBzaUtMKj6ddBpy9A3ArCBzjcpzx9Wsr1NFGKUNTLvEn-B4oQY2EFGnTIo5PuDMJum3fU05vDIMazbs7EslK4
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://cumulus-test.asf.alaska.edu/s3credentials
+  response:
+    body:
+      string: '{"accessKeyId": "FAKEACCESS", "secretAccessKey": "FAKESECRET",
+        "sessionToken": "FAKESESSION",
+        "expiration": "2025-04-08 14:22:33+00:00"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 08 Apr 2025 13:22:33 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 c45a9630d6506aeeffefe81fbc0ed0ae.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - urSCU7yuzk_Rwvsm7-TIkGi8HNb7pCE3bQX0WHxw-WPlc1pNz-wylQ==
+      X-Amz-Cf-Pop:
+      - EWR53-P1
+      X-Amzn-Trace-Id:
+      - Root=1-67f52319-45a153b02292cfa559d1ac7a;Parent=5e0feb25d9b604b6;Sampled=0;Lineage=1:c2a07d4a:0
+      X-Cache:
+      - Miss from cloudfront
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      content-encoding:
+      - gzip
+      vary:
+      - accept-encoding
+      x-amz-apigw-id:
+      - ItJsCFLrPHcEYUA=
+      x-amzn-Remapped-Connection:
+      - keep-alive
+      x-amzn-Remapped-Content-Length:
+      - '1005'
+      x-amzn-Remapped-Date:
+      - Tue, 08 Apr 2025 13:22:33 GMT
+      x-amzn-Remapped-Server:
+      - Server
+      x-amzn-Remapped-X-Forwarded-For:
+      - 65.183.145.202, 130.176.166.16
+      x-amzn-Remapped-x-amzn-RequestId:
+      - 9732a91b-4138-494b-89fc-37dac0825e99
+      x-amzn-RequestId:
+      - 9a1ed1ec-7684-4730-95ef-ce946a894ddf
+      x-request-id:
+      - 9b1b6874-b858-43fa-aed1-8a28c7a3ccd3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,226 @@
+"""Tests for the credentials module."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from opera_utils.credentials import (
+    ASFCredentialEndpoints,
+    AWSCredentials,
+    EarthdataLoginFailure,
+    get_earthdata_username_password,
+    get_temporary_aws_credentials,
+)
+
+
+def test_aws_credentials_dataclass():
+    """Test that AWSCredentials dataclass has expected methods."""
+    creds = AWSCredentials(
+        access_key_id="test_id",
+        secret_access_key="test_secret",
+        session_token="test_token",
+    )
+    # Test to_env method
+    env_vars = creds.to_env()
+    assert env_vars["AWS_ACCESS_KEY_ID"] == "test_id"
+    assert env_vars["AWS_SECRET_ACCESS_KEY"] == "test_secret"
+    assert env_vars["AWS_SESSION_TOKEN"] == "test_token"
+
+    # Test to_h5py_kwargs method
+    h5py_kwargs = creds.to_h5py_kwargs()
+    assert h5py_kwargs["secret_id"] == "test_id"
+    assert h5py_kwargs["secret_key"] == "test_secret"
+    assert h5py_kwargs["session_token"] == "test_token"
+
+
+@patch("opera_utils.credentials.get_temporary_aws_credentials")
+def test_aws_credentials_from_asf(mock_get_temp_creds):
+    """Test AWSCredentials.from_asf method."""
+    # Mock the response from get_temporary_aws_credentials
+    mock_get_temp_creds.return_value = {
+        "accessKeyId": "test_id",
+        "secretAccessKey": "test_secret",
+        "sessionToken": "test_token",
+    }
+
+    # Call the method
+    creds = AWSCredentials.from_asf(ASFCredentialEndpoints.OPERA)
+
+    # Verify the response
+    assert creds.access_key_id == "test_id"
+    assert creds.secret_access_key == "test_secret"
+    assert creds.session_token == "test_token"
+
+    # Verify the mock was called with expected args
+    mock_get_temp_creds.assert_called_once_with(ASFCredentialEndpoints.OPERA)
+
+
+@patch.dict(os.environ, {
+    "AWS_ACCESS_KEY_ID": "env_id",
+    "AWS_SECRET_ACCESS_KEY": "env_secret",
+    "AWS_SESSION_TOKEN": "env_token",
+})
+def test_aws_credentials_from_env():
+    """Test AWSCredentials.from_env method."""
+    creds = AWSCredentials.from_env()
+    assert creds.access_key_id == "env_id"
+    assert creds.secret_access_key == "env_secret"
+    assert creds.session_token == "env_token"
+
+
+def test_aws_credentials_from_env_missing_vars():
+    """Test AWSCredentials.from_env raises KeyError when env vars missing."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(KeyError):
+            AWSCredentials.from_env()
+
+
+# Need to patch the cache decorator to avoid interference between tests
+@patch("opera_utils.credentials.get_temporary_aws_credentials", wraps=get_temporary_aws_credentials)
+@patch("requests.get")
+def test_get_temporary_aws_credentials_direct(mock_requests_get, _):
+    """Test get_temporary_aws_credentials with direct response (no auth needed)."""
+    # Mock response for direct success (no auth needed)
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "accessKeyId": "direct_id",
+        "secretAccessKey": "direct_secret",
+        "sessionToken": "direct_token",
+    }
+    mock_requests_get.return_value = mock_response
+
+    # Call the function with a string endpoint to test the conversion
+    result = get_temporary_aws_credentials("OPERA", None, None)
+
+    # Verify the result
+    assert result == mock_response.json.return_value
+    mock_requests_get.assert_called_once_with(ASFCredentialEndpoints.OPERA.value)
+
+
+# Override the cache functionality to avoid test interference
+@patch("opera_utils.credentials.get_temporary_aws_credentials.__wrapped__", wraps=get_temporary_aws_credentials.__wrapped__)  
+@patch("opera_utils.credentials.get_earthdata_username_password")
+@patch("requests.get")
+def test_get_temporary_aws_credentials_with_auth(mock_requests_get, mock_get_creds, _):
+    """Test get_temporary_aws_credentials with authentication."""
+    # First response needs auth
+    auth_needed_response = MagicMock()
+    auth_needed_response.status_code = 401
+    auth_needed_response.url = "https://urs.earthdata.nasa.gov/oauth/authorize?client_id=test"
+
+    # Second response (after auth) succeeds
+    auth_success_response = MagicMock()
+    auth_success_response.status_code = 200
+    auth_success_response.json.return_value = {
+        "accessKeyId": "auth_id",
+        "secretAccessKey": "auth_secret",
+        "sessionToken": "auth_token",
+    }
+
+    # Set up mock to return different responses
+    mock_requests_get.side_effect = [auth_needed_response, auth_success_response]
+
+    # Mock the credentials
+    mock_get_creds.return_value = ("test_user", "test_pass")
+
+    # Call the function's wrapped version to bypass the cache
+    result = get_temporary_aws_credentials.__wrapped__(ASFCredentialEndpoints.OPERA, None, None)
+
+    # Verify the result
+    assert result == auth_success_response.json.return_value
+    assert mock_requests_get.call_count == 2
+    mock_requests_get.assert_any_call(ASFCredentialEndpoints.OPERA.value)
+    mock_requests_get.assert_any_call(auth_needed_response.url, auth=("test_user", "test_pass"))
+    mock_get_creds.assert_called_once_with(None, None, host="urs.earthdata.nasa.gov")
+
+
+@patch("opera_utils.credentials.get_temporary_aws_credentials.__wrapped__", wraps=get_temporary_aws_credentials.__wrapped__)
+@patch("requests.get")
+def test_get_temporary_aws_credentials_error(mock_requests_get, _):
+    """Test get_temporary_aws_credentials with HTTP error."""
+    # Mock response to raise exception
+    mock_response = MagicMock()
+    mock_response.status_code = 200  # to avoid auth path
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("Test error")
+    mock_requests_get.return_value = mock_response
+
+    # Call the function and verify it raises the expected exception
+    with pytest.raises(requests.exceptions.HTTPError, match="Test error"):
+        get_temporary_aws_credentials.__wrapped__(ASFCredentialEndpoints.OPERA, None, None)
+
+
+def test_get_earthdata_username_password_direct():
+    """Test get_earthdata_username_password with direct parameters."""
+    username, password = get_earthdata_username_password("direct_user", "direct_pass")
+    assert username == "direct_user"
+    assert password == "direct_pass"
+
+
+# To avoid test interference from environment variables
+@patch.dict(os.environ, {"EARTHDATA_USERNAME": "env_user", "EARTHDATA_PASSWORD": "env_pass"}, clear=True)
+def test_get_earthdata_username_password_from_env():
+    """Test get_earthdata_username_password from environment variables."""
+    # Mock netrc to ensure we don't use it
+    with patch("netrc.netrc") as mock_netrc:
+        mock_netrc.side_effect = FileNotFoundError()
+        
+        username, password = get_earthdata_username_password()
+        assert username == "env_user"
+        assert password == "env_pass"
+
+
+@patch("netrc.netrc")
+def test_get_earthdata_username_password_from_netrc(mock_netrc):
+    """Test get_earthdata_username_password from .netrc file."""
+    # Mock the netrc authenticators
+    mock_netrc_instance = MagicMock()
+    mock_netrc_instance.authenticators.return_value = ("netrc_user", None, "netrc_pass")
+    mock_netrc.return_value = mock_netrc_instance
+
+    # Clean environment to ensure we're testing netrc only
+    with patch.dict(os.environ, {}, clear=True):
+        username, password = get_earthdata_username_password()
+        assert username == "netrc_user"
+        assert password == "netrc_pass"
+        mock_netrc_instance.authenticators.assert_called_once_with("urs.earthdata.nasa.gov")
+
+
+@patch("netrc.netrc")
+def test_get_earthdata_username_password_no_credentials(mock_netrc):
+    """Test get_earthdata_username_password with no credentials available."""
+    # Mock netrc to return None
+    mock_netrc_instance = MagicMock()
+    mock_netrc_instance.authenticators.return_value = None
+    mock_netrc.return_value = mock_netrc_instance
+
+    # Clean environment
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="No credentials found"):
+            get_earthdata_username_password()
+
+
+@patch("netrc.netrc")
+def test_get_earthdata_username_password_netrc_error(mock_netrc):
+    """Test get_earthdata_username_password with netrc error."""
+    # Mock netrc to raise exception
+    mock_netrc.side_effect = FileNotFoundError("No .netrc file")
+
+    # Clean environment but provide direct credentials
+    with patch.dict(os.environ, {}, clear=True):
+        username, password = get_earthdata_username_password("backup_user", "backup_pass")
+        assert username == "backup_user"
+        assert password == "backup_pass"
+
+    # Clean environment with no direct credentials
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="No credentials found"):
+            get_earthdata_username_password()
+
+
+def test_get_earthdata_username_password_invalid_host():
+    """Test get_earthdata_username_password with invalid host."""
+    with pytest.raises(ValueError, match="Invalid host"):
+        get_earthdata_username_password(host="invalid.host.com")

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import netrc
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -96,6 +97,11 @@ def test_get_temporary_aws_credentials():
 @pytest.mark.vcr
 def test_get_temporary_aws_credentials_different_endpoint():
     """Test get_temporary_aws_credentials with authentication."""
+    if sys.version_info < (3, 10):
+        # Problem:
+        # ('Received response with content-encoding: gzip, but failed to decode it.',
+        #     error('Error -3 while decompressing data: incorrect header check'))
+        pytest.skip("Skipping fake decoding on Python 3.9")
     result = get_temporary_aws_credentials(endpoint="OPERA_UAT")
     expected = {
         "accessKeyId": "FAKEACCESS",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,5 +1,7 @@
 """Tests for the remote module in disp package, rewritten to use pytest monkeypatch."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -106,7 +108,7 @@ def test_open_h5_https(monkeypatch):
     mock_byte_stream = MagicMock()
     mock_fs.open.return_value = mock_byte_stream
 
-    def mock_get_https_fs(u=None, p=None, h=None):
+    def mock_get_https_fs(earthdata_username=None, earthdata_password=None, host=None):
         return mock_fs
 
     monkeypatch.setattr("opera_utils.disp._remote.get_https_fs", mock_get_https_fs)
@@ -125,7 +127,6 @@ def test_open_h5_https(monkeypatch):
         rdcc_nbytes=2000000,
         earthdata_username="test_user",
         earthdata_password="test_pass",
-        host="custom.host",
     )
 
     assert result == mock_file

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,0 +1,202 @@
+"""Tests for the remote module in disp package, rewritten to use pytest monkeypatch."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from opera_utils.credentials import AWSCredentials
+from opera_utils.disp._remote import get_https_fs, get_s3_fs, open_h5
+
+
+def test_get_https_fs(monkeypatch):
+    """Test get_https_fs function."""
+
+    # Mock get_earthdata_username_password
+    def mock_get_creds(u=None, p=None, host=None):
+        return ("test_user", "test_pass")
+
+    monkeypatch.setattr(
+        "opera_utils.disp._remote.get_earthdata_username_password", mock_get_creds
+    )
+
+    # Mock fsspec.filesystem
+    mock_fs = MagicMock()
+
+    def mock_fsspec_filesystem(protocol, **kwargs):
+        return mock_fs
+
+    monkeypatch.setattr("fsspec.filesystem", mock_fsspec_filesystem)
+
+    # Call the function
+    result = get_https_fs("custom_user", "custom_pass", "custom.host")
+
+    assert result == mock_fs
+
+
+def test_get_s3_fs_from_env(monkeypatch):
+    """Test get_s3_fs function with credentials from environment."""
+    # Mock AWSCredentials.from_env
+    mock_creds = MagicMock()
+    mock_creds.access_key_id = "env_id"
+    mock_creds.secret_access_key = "env_secret"
+    mock_creds.session_token = "env_token"
+
+    def mock_from_env():
+        return mock_creds
+
+    monkeypatch.setattr(AWSCredentials, "from_env", mock_from_env)
+
+    # Mock AWSCredentials.from_asf so we can check it does NOT get called
+    mock_from_asf = MagicMock()
+    monkeypatch.setattr(AWSCredentials, "from_asf", mock_from_asf)
+
+    # Mock s3fs.S3FileSystem
+    mock_s3fs_instance = MagicMock()
+
+    def mock_s3fs_init(*args, **kwargs):
+        return mock_s3fs_instance
+
+    monkeypatch.setattr("s3fs.S3FileSystem", mock_s3fs_init)
+
+    # Call the function
+    result = get_s3_fs()
+    assert result == mock_s3fs_instance
+
+
+def test_get_s3_fs_from_asf(monkeypatch):
+    """Test get_s3_fs function with credentials from ASF (when env fails)."""
+
+    # Make from_env raise KeyError to simulate missing env vars
+    def mock_from_env():
+        raise KeyError("No AWS credentials in environment")
+
+    monkeypatch.setattr(AWSCredentials, "from_env", mock_from_env)
+
+    # Mock AWSCredentials.from_asf
+    mock_creds = MagicMock()
+    mock_creds.access_key_id = "asf_id"
+    mock_creds.secret_access_key = "asf_secret"
+    mock_creds.session_token = "asf_token"
+
+    def mock_from_asf(endpoint):
+        return mock_creds
+
+    monkeypatch.setattr(AWSCredentials, "from_asf", mock_from_asf)
+
+    # Mock s3fs.S3FileSystem
+    mock_s3fs_instance = MagicMock()
+
+    def mock_s3fs_init(*args, **kwargs):
+        return mock_s3fs_instance
+
+    monkeypatch.setattr("s3fs.S3FileSystem", mock_s3fs_init)
+
+    # Call the function
+    result = get_s3_fs("opera-uat")
+
+    # Verify
+    assert result == mock_s3fs_instance
+
+
+def test_open_h5_https(monkeypatch):
+    """Test open_h5 with an HTTPS URL."""
+    # Mock get_https_fs
+    mock_fs = MagicMock()
+    mock_byte_stream = MagicMock()
+    mock_fs.open.return_value = mock_byte_stream
+
+    def mock_get_https_fs(u=None, p=None, h=None):
+        return mock_fs
+
+    monkeypatch.setattr("opera_utils.disp._remote.get_https_fs", mock_get_https_fs)
+
+    # Mock h5py.File
+    mock_file = MagicMock()
+
+    def mock_h5py_file(bytestream, mode="r", fs_page_size=None, rdcc_nbytes=None):
+        return mock_file
+
+    monkeypatch.setattr("h5py.File", mock_h5py_file)
+
+    result = open_h5(
+        "https://example.com/file.h5",
+        page_size=8192,
+        rdcc_nbytes=2000000,
+        earthdata_username="test_user",
+        earthdata_password="test_pass",
+        host="custom.host",
+    )
+
+    assert result == mock_file
+
+
+def test_open_h5_s3(monkeypatch):
+    """Test open_h5 with an S3 URL."""
+    # Mock get_s3_fs
+    mock_fs = MagicMock()
+    mock_byte_stream = MagicMock()
+    mock_fs.open.return_value = mock_byte_stream
+
+    def mock_get_s3_fs(asf_endpoint="opera"):
+        return mock_fs
+
+    monkeypatch.setattr("opera_utils.disp._remote.get_s3_fs", mock_get_s3_fs)
+
+    # Mock h5py.File
+    mock_file = MagicMock()
+
+    def mock_h5py_file(bytestream, mode="r", **kwargs):
+        return mock_file
+
+    monkeypatch.setattr("h5py.File", mock_h5py_file)
+
+    # Call the function
+    result = open_h5(
+        "s3://bucket/file.h5",
+        asf_endpoint="opera-uat",
+    )
+    assert result == mock_file
+
+
+def test_open_h5_local(monkeypatch):
+    """Test open_h5 with a local file path."""
+    # Mock filesystem
+    mock_fs = MagicMock()
+    mock_byte_stream = MagicMock()
+    mock_fs.open.return_value = mock_byte_stream
+
+    def mock_fsspec_filesystem(protocol):
+        return mock_fs
+
+    monkeypatch.setattr("fsspec.filesystem", mock_fsspec_filesystem)
+
+    # Mock h5py.File
+    mock_file = MagicMock()
+
+    def mock_h5py_file(bytestream, mode="r", **kwargs):
+        return mock_file
+
+    monkeypatch.setattr("h5py.File", mock_h5py_file)
+
+    # We also need to mock Path.resolve() -> path.as_uri()
+    file_path = Path("/path/to/local/file.h5")
+
+    # The object that will replace the return value of .resolve()
+    mock_resolved_path = MagicMock()
+    mock_resolved_path.as_uri.return_value = "file:///path/to/local/file.h5"
+
+    def mock_resolve(*args, **kwargs):
+        return mock_resolved_path
+
+    monkeypatch.setattr(Path, "resolve", mock_resolve)
+
+    # Call the function
+    result = open_h5(file_path)
+    assert result == mock_file
+
+
+def test_open_h5_invalid_url():
+    """Test open_h5 with an invalid URL scheme."""
+    with pytest.raises(ValueError, match="Unrecognized scheme"):
+        open_h5("ftp://example.com/file.h5")


### PR DESCRIPTION
This PR adds functionality to access OPERA DISP-S1 products stored remotely via S3 or HTTPS. You stream HDF5 files from remote sources without downloading entire files using `open_h5`. The function will 
1. (For local files) read directly
2. (for HTTPS access) look for Earthdata Login credentials
3. (For direct S3 access, on in-region EC2 instances) or use AWS credentials. They can be already set; otherwise, temporary AWS credentials will be requested using earthdata credentials.

- Added `open_h5()` in `disp._remote`
- Added `AWSCredentials`, which can be created `from_asf` (requests temporary 1-hour credentials) or `from_env` (
- Added optional `remote` dependency (`pip install opera_utils[remote]`) with `aiohttp`, `fsspec`, and `s3fs` requirements

Also fixed missing `url_type` from `get_products()` search.

An example usage:

```python
%%time
from opera_utils.disp import open_h5

url = "https://datapool-test.asf.alaska.edu/DISP/OPERA-S1/OPERA_L3_DISP-S1_IW_F11115_VV_20160810T140735Z_20160903T140736Z_v1.1_20250215T012240Z.nc"
with open_h5(url, asf_endpoint="OPERA_UAT") as hf:
    print(hf['/displacement'][3000:3002, 3000:3002])
```

This takes about 10 seconds on my laptop the first time due to redirecting authentication, and 4 seconds the second time. 

On an EC2 instance, fetching a 1000 x 1000 chunk takes about 4 seconds with authentication, or ~1 second if you have the `AWS_*` environment variables preset.


(A developer reminder for how I made the VCR cassettes:)

<details>

1. make a failing test like 

```python
    with open_h5(url, asf_endpoint="OPERA_UAT") as hf:
        print(hf.keys())
        assert "displacement" in hf.keys()
        assert hf["displacement"].shape == dp.shape
        assert hf["displacement"][4000, 4000] == 123 # fails
```
2. Run the test to record the HTTP requests:

```bash
 pytest tests/test_remote.py::test_open_h5_disp_product --pdb --record-mode rewrite
```


3. see the error: `E           assert 0.047729492 == 123`

4. Fix, then run without 
``` bash
pytest tests/test_remote.py::test_open_h5_disp_product
```

</details>