### PR TITLE
Restrict `str` usage for `ASFCredentialEndpoints`

### DIFF
--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -69,7 +69,7 @@ class AWSCredentials:
 
     @classmethod
     def from_asf(
-        cls, endpoint: str | ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA
+        cls, endpoint: ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA
     ) -> Self:
         """Get temporary AWS S3 access credentials.
 
@@ -106,7 +106,7 @@ class AWSCredentials:
 
 @cache
 def get_temporary_aws_credentials(
-    endpoint: str | ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA,
+    endpoint: ASFCredentialEndpoints = ASFCredentialEndpoints.OPERA,
     earthdata_username: str | None = None,
     earthdata_password: str | None = None,
 ) -> dict[str, str]:
@@ -138,11 +138,6 @@ def get_temporary_aws_credentials(
         If the request to the endpoint fails.
 
     """
-    endpoint = (
-        ASFCredentialEndpoints[endpoint.upper()]
-        if isinstance(endpoint, str)
-        else endpoint
-    )
     resp = requests.get(endpoint.value)
     if resp.status_code == 401 and "nasa.gov/oauth/authorize?" in resp.url:
         username, password = get_earthdata_username_password(

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -102,7 +102,7 @@ def test_get_temporary_aws_credentials_different_endpoint():
         # ('Received response with content-encoding: gzip, but failed to decode it.',
         #     error('Error -3 while decompressing data: incorrect header check'))
         pytest.skip("Skipping fake decoding on Python 3.9")
-    result = get_temporary_aws_credentials(endpoint="OPERA_UAT")
+    result = get_temporary_aws_credentials(endpoint=ASFCredentialEndpoints.OPERA_UAT)
     expected = {
         "accessKeyId": "FAKEACCESS",
         "secretAccessKey": "FAKESECRET",


### PR DESCRIPTION
Being too loose makes it harder to track the `str` key vs. value of the endpoints