### PR TITLE
Add `nan_policy` to DISP rebasing script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = "D100,D102,D104,D105,D106,D107,D203,D204,D213,D413"
 
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE NUMBER"
-addopts = "  --cov=opera_utils  --doctest-modules --randomly-seed=1234 --ignore=scripts --ignore=docs --ignore=data"
+addopts = "  --cov=opera_utils  --doctest-modules --randomly-seed=1234 --ignore=docs --ignore=data"
 filterwarnings = [
   "error",
   "ignore:h5py is running against HDF5.*:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ ignore = "D100,D102,D104,D105,D106,D107,D203,D204,D213,D413"
 
 [tool.pytest.ini_options]
 doctest_optionflags = "NORMALIZE_WHITESPACE NUMBER"
-addopts = "  --cov=opera_utils  --doctest-modules --randomly-seed=1234 --ignore=docs --ignore=data"
+addopts = "  --cov=opera_utils  --doctest-modules --randomly-seed=1234 --ignore=scripts --ignore=docs --ignore=data"
 filterwarnings = [
   "error",
   "ignore:h5py is running against HDF5.*:UserWarning",

--- a/scripts/fetch_disp.py
+++ b/scripts/fetch_disp.py
@@ -20,7 +20,6 @@ Examples
 from datetime import datetime
 from pathlib import Path
 
-import tyro
 from shapely import from_wkt
 
 from opera_utils import disp
@@ -123,4 +122,6 @@ def read_disp(
 
 
 if __name__ == "__main__":
+    import tyro
+
     tyro.cli(read_disp)

--- a/scripts/plot-disp-s1-frame.py
+++ b/scripts/plot-disp-s1-frame.py
@@ -22,7 +22,6 @@ from typing import Optional
 import cartopy.crs as ccrs
 import cartopy.io.shapereader as shpreader
 import matplotlib.pyplot as plt
-import tyro
 from shapely.ops import unary_union
 
 import opera_utils
@@ -183,4 +182,6 @@ def plot_single_frame_on_background(
 
 
 if __name__ == "__main__":
+    import tyro
+
     tyro.cli(plot_single_frame_on_background)

--- a/scripts/run_disp_s1_frame.py
+++ b/scripts/run_disp_s1_frame.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from pathlib import Path
 
 import requests
-import tyro
 
 from opera_utils.disp import rebase_reference, search
 from opera_utils.disp._rebase import NaNPolicy
@@ -132,4 +131,6 @@ def process_frame(
 
 
 if __name__ == "__main__":
+    import tyro
+
     tyro.cli(process_frame)


### PR DESCRIPTION
Currently the `nan`s propagate for pixels in any masked ministack (or really, any reference crossover product) to all subsequent days. For example, if the second ministack had slightly noisy data, but the remaining 19 ministacks are fine, we may want to view that data anyway (e.g. the velocity estimation will be fine with that much extra data, even if an offset occurs from missing 6 months).