### PR TITLE
Add alternative DISP stack reformatters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,10 @@ jobs:
       - name: Install
         run: |
           pip install .[test,disp,geopandas]
-
+      # TODO: figure out the best way to get the test data here.
+      # - name: Download test DISP data
+      #   run: |
+      #     opera-utils disp-s1-download --output-dir tests/data/subsets-new-orleans-small  --frame-id 44055 --end-datetime 2017-06-01 --wkt 'POLYGON ((-90.15 29.95, -90.15 30.1, -89.95 30.1, -89.95 29.95, -90.15 29.95))' \
       - name: Test
         run: |
           pytest -n0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup ~/.netrc
+        uses: extractions/netrc@v2
+        with:
+          machine: urs.earthdata.nasa.gov
+          username: ${{ secrets.EARTHDATA_USERNAME }}
+          password: ${{ secrets.EARTHDATA_PASSWORD }}
+
       - name: Setup environment
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -48,10 +56,11 @@ jobs:
           condarc: |
             channels:
               - conda-forge
+
       - name: Install
         run: |
-          pip install .[test,remote,geopandas]
-          pip install xarray dask
+          pip install .[test,disp,geopandas]
+
       - name: Test
         run: |
           pytest -n0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `pip` dependency list for the base package is smaller; the optional depencie
 
 ```bash
 pip install opera-utils[geopandas] # for just geopandas data frame support
-pip install opera-utils[remote] # For remote access to DISP files
+pip install opera-utils[disp] # For remote access to DISP files
 pip install opera-utils[all]  # all optional dependencies
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,5 @@ dependencies:
   - h5netcdf
   - s3fs
   - tqdm
+  - dask
+  - zarr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ opera-utils = "opera_utils.cli:cli_app"
 [project.optional-dependencies]
 # For geopandas functionality with burst/frame databases:
 geopandas = ["geopandas", "pyogrio"]
-# Access remote hdf5 files over S3 or HTTPS:
-remote = [
+# Work with DISP data - downloads and subsetting
+disp = [
   "affine",
   "botocore",
   "aiohttp",
@@ -67,9 +67,9 @@ remote = [
   "s3fs",
   "tqdm",
   "xarray",
+  "zarr>=3",
 ]
-disp = ["remote"] # Alias for remote dependencies
-all = ["opera-utils[remote,geopandas]"]
+all = ["opera-utils[disp,geopandas]"]
 
 test = [
   "asf_search",

--- a/src/opera_utils/cli.py
+++ b/src/opera_utils/cli.py
@@ -150,10 +150,12 @@ def cli_app() -> None:
     }
     try:
         from opera_utils.disp._download import run_download
+        from opera_utils.disp._reformat import reformat_stack
         from opera_utils.disp._search import search
 
         cli_dict["disp-s1-download"] = run_download
         cli_dict["disp-s1-search"] = partial(search, print_urls=True)
+        cli_dict["disp-s1-reformat"] = reformat_stack
 
     except ImportError:
         pass

--- a/src/opera_utils/disp/__init__.py
+++ b/src/opera_utils/disp/__init__.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from ._product import DispProduct, DispProductStack
+from ._rebase import rebase_timeseries
+from ._reformat import reformat_stack
 from ._remote import open_file, open_h5
 from ._search import search
-from ._xarray import create_rebased_stack
+from ._xarray import create_rebased_displacement
 
 __all__ = [
     "DispProduct",
     "DispProductStack",
-    "create_rebased_stack",
+    "create_rebased_displacement",
     "open_file",
     "open_h5",
+    "rebase_timeseries",
     "search",
 ]

--- a/src/opera_utils/disp/_download.py
+++ b/src/opera_utils/disp/_download.py
@@ -101,7 +101,7 @@ def run_download(
     bbox: tuple[float, float, float, float] | None = None,
     wkt: str | None = None,
     url_type: UrlType = UrlType.HTTPS,
-    num_workers: int = 20,
+    num_workers: int = 8,
     product_version: str | None = "1.0",
     output_dir: Path = Path("./subsets"),
 ) -> list[Path]:

--- a/src/opera_utils/disp/_enums.py
+++ b/src/opera_utils/disp/_enums.py
@@ -1,0 +1,60 @@
+from enum import Enum
+
+
+class DisplacementDataset(str, Enum):
+    """Enumeration of displacement datasets."""
+
+    DISPLACEMENT = "displacement"
+    SHORT_WAVELENGTH = "short_wavelength_displacement"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class CorrectionDataset(str, Enum):
+    """Enumeration of correction datasets."""
+
+    SOLID_EARTH_TIDE = "/corrections/solid_earth_tide"
+    IONOSPHERIC_DELAY = "/corrections/ionospheric_delay"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class SamePerMinistackDataset(str, Enum):
+    """Enumeration of datasets that are same per ministack."""
+
+    TEMPORAL_COHERENCE = "temporal_coherence"
+    PHASE_SIMILARITY = "phase_similarity"
+    PERSISTENT_SCATTERER_MASK = "persistent_scatterer_mask"
+    SHP_COUNTS = "shp_counts"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class QualityDataset(str, Enum):
+    """Enumeration of quality datasets."""
+
+    TIMESERIES_INVERSION_RESIDUALS = "timeseries_inversion_residuals"
+    CONNECTED_COMPONENT_LABELS = "connected_component_labels"
+    RECOMMENDED_MASK = "recommended_mask"
+    ESTIMATED_PHASE_QUALITY = "estimated_phase_quality"
+    SHP_COUNTS = "shp_counts"
+    WATER_MASK = "water_mask"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+SAME_PER_MINISTACK_DATASETS = [
+    SamePerMinistackDataset.TEMPORAL_COHERENCE,
+    SamePerMinistackDataset.PHASE_SIMILARITY,
+    SamePerMinistackDataset.PERSISTENT_SCATTERER_MASK,
+    SamePerMinistackDataset.SHP_COUNTS,
+]
+UNIQUE_PER_DATE_DATASETS = [
+    QualityDataset.TIMESERIES_INVERSION_RESIDUALS,
+    QualityDataset.CONNECTED_COMPONENT_LABELS,
+    QualityDataset.RECOMMENDED_MASK,
+]

--- a/src/opera_utils/disp/_netcdf.py
+++ b/src/opera_utils/disp/_netcdf.py
@@ -1,0 +1,90 @@
+"""Module to concatenate displacement tiles into a CF-compliant virtual dataset.
+
+Note that in-place modification of the virtual file will change the original
+underlying data.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+
+def create_virtual_stack(
+    input_files: Sequence[Path | str],
+    output: Path | str,
+    dataset_names: Sequence[str] | None = None,
+    drop_vars: Sequence[str] | None = None,
+) -> None:
+    """Concatenate single-date NetCDF displacement files into a stack.
+
+    Uses the virtual HDF5 stack along the time dimension.
+    See https://docs.h5py.org/en/stable/vds.html for more info.
+
+    Parameters
+    ----------
+    input_files : list[pathlib.Path]
+        Source NetCDF/CF files.
+    output : pathlib.Path
+        Path of the VDS file to create. Suffix may be “.nc” or “.h5”.
+    dataset_names : Sequence[str], optional
+        Names of the 2-D variable to concatenate and include in `output`.
+        If None provided, creates for all 2D datasets in `input_files`.
+    drop_vars : Sequence[str], optional
+        Names of variables to drop from the dataset before saving.
+        Useful if you are saving all but a few variables from `input_files`.
+
+    """
+    if not input_files:
+        msg = "No input files provided."
+        raise ValueError(msg)
+
+    if dataset_names is None:
+        dataset_names = _get_2d_datasets(input_files[0])
+
+    if drop_vars is None:
+        drop_vars = []
+
+    data_vars = [name for name in dataset_names if name not in drop_vars]
+
+    # Inspect the first file to determine shapes, dtype, & metadata
+    with h5py.File(input_files[0], "r") as hf0:
+        ny, nx = hf0["displacement"].shape
+        name_to_dtype = {name: hf0[name].dtype for name in dataset_names}
+
+    n_time = len(input_files)
+
+    with h5py.File(output, "r+", libver="latest") as hf:
+        time_ds = hf["time"]
+        y_ds = hf["y"]
+        x_ds = hf["x"]
+        for dataset_name in data_vars:
+            dtype = name_to_dtype[dataset_name]
+            layout = h5py.VirtualLayout(shape=(n_time, ny, nx), dtype=dtype)
+            for k, src in enumerate(map(str, input_files)):
+                layout[k, :, :] = h5py.VirtualSource(src, dataset_name, shape=(ny, nx))
+            dset = hf.create_virtual_dataset(dataset_name, layout, fillvalue=np.nan)
+
+            # Add attributes
+            dset.attrs.update(hf[dataset_name].attrs)
+
+            # Attach dimension scales → proper CF & GDAL recognition
+            dset.dims[0].attach_scale(time_ds)
+            dset.dims[1].attach_scale(y_ds)
+            dset.dims[2].attach_scale(x_ds)
+            dset.attrs["grid_mapping"] = "spatial_ref"
+
+
+def _get_2d_datasets(filename: Path | str) -> list[str]:
+    names = []
+
+    def _add_name(name):
+        if isinstance(hf[name], h5py.Dataset) and hf[name].ndim == 2:
+            names.append(name)
+
+    with h5py.File(filename) as hf:
+        hf.visit(_add_name)
+    return names

--- a/src/opera_utils/disp/_product.py
+++ b/src/opera_utils/disp/_product.py
@@ -11,6 +11,7 @@ from math import nan
 from pathlib import Path
 from typing import Any
 
+import h5py
 import numpy as np
 import pandas as pd
 import pyproj
@@ -113,14 +114,23 @@ class DispProduct:
 
     @property
     def shape(self) -> tuple[int, int]:
-        left, bottom, right, top = self._frame_bbox_result[1]
-        return (round((top - bottom) / 30), round((right - left) / 30))
+        # First check if files actually exist
+        if not Path(self.filename).exists():
+            # If not, assume the full size shape:
+            left, bottom, right, top = self._frame_bbox_result[1]
+            return (round((top - bottom) / 30), round((right - left) / 30))
+        # Otherwise, read the shape from the file
+        with h5py.File(self.filename) as f:
+            return f["displacement"].shape
 
     @cached_property
     def _coordinates(self) -> tuple[np.ndarray, np.ndarray]:
-        from ._utils import get_frame_coordinates
+        if not Path(self.filename).exists():
+            from ._utils import get_frame_coordinates
 
-        return get_frame_coordinates(self.frame_id)
+            return get_frame_coordinates(self.frame_id)
+        with h5py.File(self.filename) as f:
+            return f["x"][()], f["y"][()]
 
     @property
     def x(self) -> np.ndarray:
@@ -132,8 +142,13 @@ class DispProduct:
 
     @property
     def transform(self) -> Affine:
-        left, _bottom, _right, top = self._frame_bbox_result[1]
-        return Affine(30, 0, left, 0, -30, top)
+        if not Path(self.filename).exists():
+            left, _bottom, _right, top = self._frame_bbox_result[1]
+            return Affine(30, 0, left, 0, -30, top)
+        with h5py.File(self.filename) as f:
+            x0, y0 = f["x"][0], f["y"][0]
+            # Shift by half a pixel
+            return Affine(30, 0, x0 - 15, 0, -30, y0 + 15)
 
     def get_rasterio_profile(self, chunks: tuple[int, int] = (256, 256)) -> dict:
         """Generate a `profile` usable by `rasterio.open()`."""
@@ -149,7 +164,6 @@ class DispProduct:
             "count": 1,
         }
         # Add frame georeferencing metadata
-        left, bottom, right, top = self._frame_bbox_result[1]
         profile["width"] = self.shape[1]
         profile["height"] = self.shape[0]
         profile["transform"] = self.transform
@@ -294,9 +308,13 @@ class DispProductStack:
         """Convert the longitude and latitude (in degrees) row/column indices."""
         return lonlat_to_rowcol(self.products[0], lon, lat)
 
-    def to_dataframe(self) -> pd.DataFrame:
+    def to_dataframe(self, strip_timezone: bool = True) -> pd.DataFrame:
         """Create a DataFrame holding the product stack metadata."""
-        return pd.DataFrame([asdict(p) for p in self.products])
+        df = pd.DataFrame([asdict(p) for p in self.products])
+        if strip_timezone:
+            df.reference_datetime = df.reference_datetime.dt.tz_localize(None)
+            df.secondary_datetime = df.secondary_datetime.dt.tz_localize(None)
+        return df
 
 
 def _get_download_url(

--- a/src/opera_utils/disp/_product.py
+++ b/src/opera_utils/disp/_product.py
@@ -308,13 +308,9 @@ class DispProductStack:
         """Convert the longitude and latitude (in degrees) row/column indices."""
         return lonlat_to_rowcol(self.products[0], lon, lat)
 
-    def to_dataframe(self, strip_timezone: bool = True) -> pd.DataFrame:
+    def to_dataframe(self) -> pd.DataFrame:
         """Create a DataFrame holding the product stack metadata."""
-        df = pd.DataFrame([asdict(p) for p in self.products])
-        if strip_timezone:
-            df.reference_datetime = df.reference_datetime.dt.tz_localize(None)
-            df.secondary_datetime = df.secondary_datetime.dt.tz_localize(None)
-        return df
+        return pd.DataFrame([asdict(p) for p in self.products])
 
 
 def _get_download_url(

--- a/src/opera_utils/disp/_reformat.py
+++ b/src/opera_utils/disp/_reformat.py
@@ -1,13 +1,13 @@
 """NetCDF to Zarr reformatter for displacement product stacks."""
 
 # /// script
-# dependencies = ['dask', 'zarr', 'xarray', 'opera_utils[disp]']
+# dependencies = ['zarr>=3', 'xarray', 'opera_utils[disp]']
 # ///
 import time
 from collections.abc import Sequence
 from pathlib import Path
 
-import dask.distributed
+import pandas as pd
 import tyro
 import xarray as xr
 from zarr.codecs import BloscCodec
@@ -22,7 +22,6 @@ def reformat_stack(
     output_name: str,
     out_chunks: tuple[int, int, int] = (5, 256, 256),
     drop_vars: Sequence[str] | None = None,
-    num_workers: int = 1,
 ) -> None:
     """Reformat NetCDF displacement files to Zarr format with compression.
 
@@ -39,13 +38,9 @@ def reformat_stack(
     drop_vars : list of str, optional
         list of variable names to drop from the dataset before saving.
         Example: ["estimated_phase_quality"]
-    num_workers : int, optional
-        Number of workers for Dask distributed processing. If 1, skips using
-        the distributed client.
 
     """
     start_time = time.time()
-    # TODO: how to handle netcdf/zarr output
     # TODO: is there a special way to save geo metadata with zarr?
     # or GeoZarr still too in flux?
     if Path(output_name).suffix == ".nc":
@@ -56,28 +51,21 @@ def reformat_stack(
         msg = "Only .nc and .zarr output formats are supported"
         raise ValueError(msg)
 
-    # Set up parallel processing
-    if num_workers == 1:
-        client = None
-    else:
-        client_kwargs = {"n_workers": num_workers}
-        client = dask.distributed.Client(**client_kwargs)
-        print("Setting up Dask distributed client")
-        print(f"Dask client: {client}")
-
     # Set default chunks if none provided
     out_chunk_dict = dict(zip(["time", "y", "x"], out_chunks))
     dps = disp.DispProductStack.from_file_list(input_files)
     df = dps.to_dataframe()
 
-    # First, save the template/coordinates/water mask only
+    # #####################
+    # Write minimal dataset
+    # #####################
     ds = xr.open_mfdataset(dps.filenames)
     # Drop specified variables if requested
     if drop_vars:
         print(f"Dropping variables: {drop_vars}")
         ds = ds.drop_vars(drop_vars, errors="ignore")
 
-    # Drop all except x/y/time
+    # Here we just want the output template/coordinates/water mask
     all_vars = list(ds.data_vars)
     minimal_vars = ["spatial_ref", "reference_time", "water_mask"]
     ds_minimal = ds.drop_vars([v for v in all_vars if v not in minimal_vars])
@@ -95,29 +83,19 @@ def reformat_stack(
         )
     print(f"Wrote minimal dataset: {time.time() - start_time:.1f}s")
 
-    # ############
-    # Create rebased stack with specified chunking
+    # #########################
+    # Rebase displacement array
+    # #########################
     print(f"Creating rebased stack with chunks: {out_chunk_dict}")
-    da_disp = disp.create_rebased_displacement(
-        ds.displacement,
-        df.reference_datetime,
-    )
-    da_disp = da_disp.assign_coords(spatial_ref=ds.spatial_ref)
-    ds_disp = da_disp.to_dataset(name="displacement")
-
-    if out_format == "zarr":
-        encoding = _get_zarr_encoding(ds_disp, out_chunks)
-        ds_disp.to_zarr(output_name, encoding=encoding, mode="a")
-    else:
-        encoding = _get_netcdf_encoding(ds_disp, out_chunks)
-        ds_disp.to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="a")
+    _write_rebased_stack(ds, df, output_name, out_chunks, out_format)
     print(f"Wrote displacement: {time.time() - start_time:.1f}s")
 
+    # #########################
+    # Write remaining variables
+    # #########################
     ds_remaining = ds[UNIQUE_PER_DATE_DATASETS + SAME_PER_MINISTACK_DATASETS].chunk(
         out_chunk_dict
     )
-
-    # ############
     print(f"Writing remaining variables: {ds_remaining.data_vars}")
     # Now here, we'll use the virtual dataset feature of HDF5 if we're writing NetCDF
     if out_format == "zarr":
@@ -136,19 +114,27 @@ def reformat_stack(
         )
     print(f"Wrote remaining: {time.time() - start_time:.1f}s")
 
-    _print_summary(output_name, start_time)
 
-
-def _print_summary(output_name: Path | str, start_time: float) -> None:
-    # Report completion
-    elapsed_time = time.time() - start_time
-    file_size = sum(
-        f.stat().st_size for f in Path(output_name).rglob("*") if f.is_file()
+def _write_rebased_stack(
+    ds: xr.Dataset,
+    df: pd.DataFrame,
+    output_name: Path | str,
+    out_chunks: tuple[int, int, int],
+    out_format: str = "zarr",
+) -> None:
+    da_disp = disp.create_rebased_displacement(
+        ds.displacement,
+        # Need to strip timezone to match the ds.time coordinates
+        df.reference_datetime.dt.tz_localize(None),
     )
-    file_size_mb = file_size / (1024 * 1024)
-    print(f"Successfully created {output_name}")
-    print(f"File size: {file_size_mb:.1f} MB")
-    print(f"Completed in {elapsed_time:.1f} seconds")
+    da_disp = da_disp.assign_coords(spatial_ref=ds.spatial_ref)
+    ds_disp = da_disp.to_dataset(name="displacement")
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_disp, out_chunks)
+        ds_disp.to_zarr(output_name, encoding=encoding, mode="a")
+    else:
+        encoding = _get_netcdf_encoding(ds_disp, out_chunks)
+        ds_disp.to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="a")
 
 
 def _get_netcdf_encoding(
@@ -196,22 +182,6 @@ def _get_zarr_encoding(
     # Handle coordinate compression
     encoding.update({var: {"compressors": []} for var in ds.coords})
     return encoding
-
-
-# Data variables:
-#  spatial_ref                     (time) int64 240B 0 0
-#  reference_time                  (time) datetime64[ns]
-#  displacement                    (time, y, x) float32
-#  short_wavelength_displacement   (time, y, x) float32
-#  recommended_mask                (time, y, x) float32
-#  connected_component_labels      (time, y, x) float32
-#  temporal_coherence              (time, y, x) float32
-#  estimated_phase_quality         (time, y, x) float32
-#  persistent_scatterer_mask       (time, y, x) float32
-#  shp_counts                      (time, y, x) float32
-#  water_mask                      (time, y, x) float32
-#  phase_similarity                (time, y, x) float32
-#  timeseries_inversion_residuals  (time, y, x) float32
 
 
 if __name__ == "__main__":

--- a/src/opera_utils/disp/_reformat.py
+++ b/src/opera_utils/disp/_reformat.py
@@ -1,0 +1,205 @@
+"""NetCDF to Zarr reformatter for displacement product stacks."""
+
+# /// script
+# dependencies = ['dask', 'zarr', 'xarray', 'opera_utils[disp]']
+# ///
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+import dask.distributed
+import tyro
+import xarray as xr
+from zarr.codecs import BloscCodec
+
+from opera_utils import disp
+
+from ._enums import (
+    SAME_PER_MINISTACK_DATASETS,
+    UNIQUE_PER_DATE_DATASETS,
+)
+
+
+def reformat_stack(
+    input_files: list[Path],
+    output_name: str,
+    out_chunks: tuple[int, int, int] = (5, 256, 256),
+    drop_vars: Sequence[str] | None = None,
+    num_workers: int = 1,
+) -> None:
+    """Reformat NetCDF displacement files to Zarr format with compression.
+
+    Parameters
+    ----------
+    input_files : Sequence[Path]
+        Input NetCDF files.
+    output_name : str
+        Name of the output file.
+        Must end in ".nc" or ".zarr".
+    out_chunks : tuple[int, int, int]
+        Chunking configuration for output DataArray.
+        Defaults to DEFAULT_CHUNKS, which is {"time": 5, "x": 256, "y": 256}
+    drop_vars : list of str, optional
+        list of variable names to drop from the dataset before saving.
+        Example: ["estimated_phase_quality"]
+    num_workers : int, optional
+        Number of workers for Dask distributed processing. If 1, skips using
+        the distributed client.
+
+    """
+    start_time = time.time()
+    # TODO: how to handle netcdf/zarr output
+    # TODO: is there a special way to save geo metadata with zarr?
+    # or GeoZarr still too in flux?
+    if Path(output_name).suffix == ".nc":
+        out_format = "h5netcdf"
+    elif Path(output_name).suffix == ".zarr":
+        out_format = "zarr"
+    else:
+        msg = "Only .nc and .zarr output formats are supported"
+        raise ValueError(msg)
+
+    # Set up parallel processing
+    if num_workers == 1:
+        client = None
+    else:
+        client_kwargs = {"n_workers": num_workers}
+        client = dask.distributed.Client(**client_kwargs)
+        print("Setting up Dask distributed client")
+        print(f"Dask client: {client}")
+
+    # Set default chunks if none provided
+    out_chunk_dict = dict(zip(["time", "y", "x"], out_chunks))
+    dps = disp.DispProductStack.from_file_list(input_files)
+    df = dps.to_dataframe()
+
+    # First, save the template/coordinates/water mask only
+    ds = xr.open_mfdataset(dps.filenames)
+    # Drop specified variables if requested
+    if drop_vars:
+        print(f"Dropping variables: {drop_vars}")
+        ds = ds.drop_vars(drop_vars, errors="ignore")
+
+    # Drop all except x/y/time
+    all_vars = list(ds.data_vars)
+    minimal_vars = ["spatial_ref", "reference_time", "water_mask"]
+    ds_minimal = ds.drop_vars([v for v in all_vars if v not in minimal_vars])
+    # Only keep one water mask, as it's repeated for all frame outputs
+    ds_minimal["water_mask"] = ds_minimal["water_mask"].isel(time=0)
+
+    # Configure compression encoding
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_minimal, out_chunks, add_coords=True)
+        ds_minimal.to_zarr(output_name, encoding=encoding, mode="w")
+    else:
+        encoding = _get_netcdf_encoding(ds_minimal, out_chunks)
+        ds_minimal.to_netcdf(
+            output_name, engine="h5netcdf", encoding=encoding, mode="w"
+        )
+    print(f"Wrote minimal dataset: {time.time() - start_time:.1f}s")
+
+    # Create rebased stack with specified chunking
+    print(f"Creating rebased stack with chunks: {out_chunk_dict}")
+    da_disp = disp.create_rebased_displacement(
+        ds.displacement,
+        df.reference_datetime,
+    )
+    da_disp = da_disp.assign_coords(spatial_ref=ds.spatial_ref)
+    ds_disp = da_disp.to_dataset(name="displacement")
+    print(f"Rebased displacement: {time.time() - start_time:.1f}s")
+
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_disp, out_chunks)
+        ds_disp.to_zarr(output_name, encoding=encoding, mode="a")
+    else:
+        encoding = _get_netcdf_encoding(ds_disp, out_chunks)
+        ds_disp.to_netcdf(output_name, engine="h5netcdf", encoding=encoding, mode="a")
+    print(f"Wrote displacement: {time.time() - start_time:.1f}s")
+
+    ds_remaining = ds[UNIQUE_PER_DATE_DATASETS + SAME_PER_MINISTACK_DATASETS].chunk(
+        out_chunk_dict
+    )
+
+    print(f"Writing remaining variables: {ds_remaining.data_vars}")
+    if out_format == "zarr":
+        encoding = _get_zarr_encoding(ds_remaining, out_chunks)
+        ds_remaining.to_zarr(output_name, encoding=encoding, mode="a")
+    else:
+        encoding = _get_netcdf_encoding(ds_remaining, out_chunks)
+        ds_remaining.to_netcdf(
+            output_name, engine="h5netcdf", encoding=encoding, mode="a"
+        )
+    print(f"Wrote remaining: {time.time() - start_time:.1f}s")
+
+    # Report completion
+    elapsed_time = time.time() - start_time
+    file_size = sum(
+        f.stat().st_size for f in Path(output_name).rglob("*") if f.is_file()
+    )
+    file_size_mb = file_size / (1024 * 1024)
+
+    print(f"Successfully created {output_name}")
+    print(f"File size: {file_size_mb:.1f} MB")
+    print(f"Completed in {elapsed_time:.1f} seconds")
+
+
+def _get_netcdf_encoding(
+    ds: xr.Dataset,
+    chunks: tuple[int, int, int],
+    compression_level: int = 6,
+    data_vars: Sequence[str] = [],
+) -> dict:
+    encoding = {}
+    comp = {"zlib": True, "complevel": compression_level, "chunks": chunks}
+    if not data_vars:
+        data_vars = list(ds.data_vars)
+    encoding = {var: comp for var in data_vars if ds[var].ndim >= 2}
+    return encoding
+
+
+def _get_zarr_encoding(
+    ds: xr.Dataset,
+    chunks: tuple[int, int, int],
+    add_coords: bool = False,
+    compression_name: str = "zstd",
+    compression_level: int = 6,
+    data_vars: Sequence[str] = [],
+) -> dict:
+    # out_chunk_dict = dict(zip(["time", "y", "x"], chunks))
+    encoding_per_var = {
+        "compressors": [
+            BloscCodec(
+                cname=compression_name,
+                clevel=compression_level,
+            )
+        ],
+        "chunks": chunks,
+    }
+    if not data_vars:
+        data_vars = list(ds.data_vars)
+    encoding = {var: encoding_per_var for var in data_vars if ds[var].ndim >= 2}
+    if not add_coords:
+        return encoding
+    # Handle coordinate compression
+    encoding.update({var: {"compressors": []} for var in ds.coords})
+    return encoding
+
+
+# Data variables:
+#  spatial_ref                     (time) int64 240B 0 0
+#  reference_time                  (time) datetime64[ns]
+#  displacement                    (time, y, x) float32
+#  short_wavelength_displacement   (time, y, x) float32
+#  recommended_mask                (time, y, x) float32
+#  connected_component_labels      (time, y, x) float32
+#  temporal_coherence              (time, y, x) float32
+#  estimated_phase_quality         (time, y, x) float32
+#  persistent_scatterer_mask       (time, y, x) float32
+#  shp_counts                      (time, y, x) float32
+#  water_mask                      (time, y, x) float32
+#  phase_similarity                (time, y, x) float32
+#  timeseries_inversion_residuals  (time, y, x) float32
+
+
+if __name__ == "__main__":
+    tyro.cli(reformat_stack)

--- a/src/opera_utils/disp/_utils.py
+++ b/src/opera_utils/disp/_utils.py
@@ -61,7 +61,7 @@ def _last_per_ministack(
     return last_per_ministack
 
 
-def round_mantissa(z: np.ndarray, keep_bits=10) -> None:
+def round_mantissa(z: np.ndarray, keep_bits=10) -> np.ndarray:
     """Zero out mantissa bits of elements of array in place.
 
     Drops a specified number of bits from the floating point mantissa,
@@ -75,6 +75,11 @@ def round_mantissa(z: np.ndarray, keep_bits=10) -> None:
         Number of bits to preserve in mantissa. Defaults to 10.
         Lower numbers will truncate the mantissa more and enable
         more compression.
+
+    Returns
+    -------
+    np.ndarray
+        View of input `z` array with rounded mantissa.
 
     References
     ----------

--- a/src/opera_utils/disp/_utils.py
+++ b/src/opera_utils/disp/_utils.py
@@ -121,3 +121,14 @@ def _get_border(data_arrays: NDArray[np.floating]) -> NDArray[np.floating]:
     right_col = data_arrays[:, :, -1]
     all_pixels = np.hstack([top_row, bottom_row, left_col, right_col])
     return np.nanmedian(all_pixels, axis=1)[:, np.newaxis, np.newaxis]
+
+
+def _ensure_chunks(
+    requested_chunks: dict[str, int] | None, data_shape: tuple[int, int, int]
+) -> dict[str, int]:
+    """Ensure requested_chunks are smaller than the downloaded size."""
+    chunks = {**(requested_chunks or {})}
+    chunks["time"] = min(chunks["time"], data_shape[0])
+    chunks["y"] = min(chunks["y"], data_shape[1])
+    chunks["x"] = min(chunks["x"], data_shape[2])
+    return chunks

--- a/src/opera_utils/disp/_xarray.py
+++ b/src/opera_utils/disp/_xarray.py
@@ -117,7 +117,7 @@ def _create_initial_epoch(df: pd.DataFrame, first_stack: xr.Dataset) -> xr.Datas
     """Create initial reference epoch with zero displacement."""
     # Get earliest date from the dataframe
     first_epoch = df.reference_datetime.min()
-    first_epoch_dt64 = np.datetime64(first_epoch.to_pydatetime())
+    first_epoch_dt64 = np.datetime64(first_epoch.to_pydatetime(), "ns")
 
     # Create zero-valued dataset matching spatial structure
     initial_ds = xr.full_like(first_stack.isel(time=0), 0)

--- a/src/opera_utils/disp/rebase_reference.py
+++ b/src/opera_utils/disp/rebase_reference.py
@@ -84,10 +84,10 @@ def rebase(
         Name of HDF5 dataset within product to use as a mask.
         If None, no masking is performed.
     apply_solid_earth_corrections : bool
-        Apply solid earth tides to the data.
+        Apply solid earth tide correction to the data.
         Default is True.
     apply_ionospheric_corrections : bool
-        Apply ionospheric delay to the data.
+        Apply ionospheric delay correction to the data.
         Default is True.
     nan_policy : str | NaNPolicy
         Whether to propagate or omit (zero out) NaNs in the data.

--- a/src/opera_utils/disp/rebase_reference.py
+++ b/src/opera_utils/disp/rebase_reference.py
@@ -23,7 +23,6 @@ from collections.abc import Sequence
 from concurrent.futures import FIRST_EXCEPTION, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import date, datetime
-from enum import Enum
 from itertools import repeat
 from pathlib import Path
 from typing import Any, Final, Literal
@@ -36,70 +35,19 @@ from rasterio.enums import Resampling
 from tqdm.auto import trange
 from typing_extensions import Self
 
+from ._enums import (
+    SAME_PER_MINISTACK_DATASETS,
+    UNIQUE_PER_DATE_DATASETS,
+    CorrectionDataset,
+    DisplacementDataset,
+    QualityDataset,
+)
 from ._product import DispProductStack
 from ._rebase import NaNPolicy
 from ._utils import _last_per_ministack, flatten, round_mantissa
 
 UINT16_MAX: Final = 65535
 
-
-class DisplacementDataset(str, Enum):
-    """Enumeration of displacement datasets."""
-
-    DISPLACEMENT = "displacement"
-    SHORT_WAVELENGTH = "short_wavelength_displacement"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class CorrectionDataset(str, Enum):
-    """Enumeration of correction datasets."""
-
-    SOLID_EARTH_TIDE = "/corrections/solid_earth_tide"
-    IONOSPHERIC_DELAY = "/corrections/ionospheric_delay"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class SamePerMinistackDataset(str, Enum):
-    """Enumeration of datasets that are same per ministack."""
-
-    TEMPORAL_COHERENCE = "temporal_coherence"
-    PHASE_SIMILARITY = "phase_similarity"
-    PERSISTENT_SCATTERER_MASK = "persistent_scatterer_mask"
-    SHP_COUNTS = "shp_counts"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class QualityDataset(str, Enum):
-    """Enumeration of quality datasets."""
-
-    TIMESERIES_INVERSION_RESIDUALS = "timeseries_inversion_residuals"
-    CONNECTED_COMPONENT_LABELS = "connected_component_labels"
-    RECOMMENDED_MASK = "recommended_mask"
-    ESTIMATED_PHASE_QUALITY = "estimated_phase_quality"
-    SHP_COUNTS = "shp_counts"
-    WATER_MASK = "water_mask"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-SAME_PER_MINISTACK_DATASETS = [
-    SamePerMinistackDataset.TEMPORAL_COHERENCE,
-    SamePerMinistackDataset.PHASE_SIMILARITY,
-    SamePerMinistackDataset.PERSISTENT_SCATTERER_MASK,
-    SamePerMinistackDataset.SHP_COUNTS,
-]
-UNIQUE_PER_DATE_DATASETS = [
-    QualityDataset.TIMESERIES_INVERSION_RESIDUALS,
-    QualityDataset.CONNECTED_COMPONENT_LABELS,
-    QualityDataset.RECOMMENDED_MASK,
-]
 
 NODATA_VALUES = {
     "shp_counts": 0,

--- a/src/opera_utils/geometry.py
+++ b/src/opera_utils/geometry.py
@@ -16,6 +16,8 @@ from opera_utils._types import Bbox, PathOrStr
 from opera_utils._utils import format_nc_filename, scratch_directory
 from opera_utils.download import download_cslc_static_layers
 
+gdal.UseExceptions()
+
 logger = logging.getLogger(__name__)
 
 EXTRA_COMPRESSED_TIFF_OPTIONS = (

--- a/src/opera_utils/stitching.py
+++ b/src/opera_utils/stitching.py
@@ -21,6 +21,8 @@ from opera_utils._utils import _get_path_from_gdal_str, numpy_to_gdal_type
 
 logger = logging.getLogger(__name__)
 
+gdal.UseExceptions()
+
 DEFAULT_TIFF_OPTIONS = (
     "COMPRESS=DEFLATE",
     "ZLEVEL=4",

--- a/tests/test_disp_reformat.py
+++ b/tests/test_disp_reformat.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+import xarray as xr
+
+from opera_utils.disp import reformat_stack
+from opera_utils.disp._enums import (
+    SAME_PER_MINISTACK_DATASETS,
+    UNIQUE_PER_DATE_DATASETS,
+)
+
+# UserWarning: Consolidated metadata is currently not part in the Zarr format 3 specification.
+# zarr/api/asynchronous.py:203: UserWarning: Consolidated metadata is currently not
+# part in the Zarr format 3 specification.
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:.*Consolidated metadata is currently not part in the Zarr format 3"
+    " specification.*:UserWarning",
+)
+
+
+INPUT_DISP_S1_DIR = Path(__file__).parent / "data" / "subsets-new-orleans-small"
+SKIP_TESTS = len(list(INPUT_DISP_S1_DIR.glob("*.nc"))) == 0
+
+
+@pytest.mark.skipif(
+    SKIP_TESTS, reason=f"No DISP-S1 input files found in {INPUT_DISP_S1_DIR}"
+)
+def test_reformat_stack_zarr(tmp_path):
+    input_files = list(INPUT_DISP_S1_DIR.glob("*.nc"))
+    output_name = tmp_path / "test.zarr"
+
+    reformat_stack(input_files=input_files, output_name=output_name)
+
+    # Inspect results
+    ds = xr.open_zarr(output_name)
+    for ds_name in UNIQUE_PER_DATE_DATASETS + SAME_PER_MINISTACK_DATASETS:
+        assert ds_name in ds.data_vars
+
+
+@pytest.mark.skipif(
+    SKIP_TESTS, reason=f"No DISP-S1 input files found in {INPUT_DISP_S1_DIR}"
+)
+def test_reformat_stack_netcdf(tmp_path):
+    input_files = list(INPUT_DISP_S1_DIR.glob("*.nc"))
+    output_name = tmp_path / "test.nc"
+
+    reformat_stack(input_files=input_files, output_name=output_name)
+
+    # Inspect results
+    ds = xr.open_dataset(output_name, engine="h5netcdf")
+    for ds_name in UNIQUE_PER_DATE_DATASETS + SAME_PER_MINISTACK_DATASETS:
+        assert ds_name in ds.data_vars


### PR DESCRIPTION
This PR allows us to get a similar outcome to the `rebase_timeseries`, but aims to have simpler logic (by using xarray) and outputs one 3D stack (instead of a directory of GeoTIFFs).

Some high level notes about the result:
- A ~1500x1500 subset with 210 dates runs in ~90 seconds on my laptop. 
- By default I'm skipping writing `short_wavelength_displacement` and `estimated_phase_quality`
- The input subsetted NetCDFs are about 4.5GB; the resulting compressed zarr stack is 2 GB
For comparison, the `rebase_reference` script writing GeoTIFFs takes ~3.5 minutes, and the resulting direction is ~3 GB.

Formats right now are Zarr and (virtual) Netcdf. The "virtual" part uses the [virtual dataset](https://docs.h5py.org/en/stable/vds.html) feature of hdf5 to avoid copying the layers which are direct transfers (e.g. temporal_coherence, phase_similarity, ...). The Zarr output currently runs faster, largely because xarray/dask are better at writing to Zarr in parallel.

But I'm picturing that the NetCDF output could useful for people who want to make MintPy-compatible `timeseries.h5` files, without duplicating the input data.