### PR TITLE
Add rasterio to `[disp]` optional install 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ disp = [
   "h5netcdf",
   "s3fs",
   "tqdm",
+  "rasterio",
   "xarray",
   "zarr>=3",
 ]

--- a/src/opera_utils/credentials.py
+++ b/src/opera_utils/credentials.py
@@ -234,3 +234,8 @@ def get_earthdata_username_password(
         f" '{host}' entry, nor environment variables set."
     )
     raise EarthdataLoginError(msg)
+
+
+if __name__ == "__main__":
+    for k, v in AWSCredentials.from_asf().to_env().items():
+        print(f"export {k}={v}")

--- a/src/opera_utils/disp/_reformat.py
+++ b/src/opera_utils/disp/_reformat.py
@@ -258,6 +258,14 @@ def reformat_stack(
                 str(ds) for ds in UNIQUE_PER_DATE_DATASETS + SAME_PER_MINISTACK_DATASETS
             ],
         )
+        # Write the extra "average_temporal_coherence"
+        encoding = _get_netcdf_encoding(
+            ds_remaining[["average_temporal_coherence"]], out_chunks
+        )
+        ds_remaining[["average_temporal_coherence"]].to_netcdf(
+            output_name, engine="h5netcdf", encoding=encoding, mode="a"
+        )
+
     print(f"Wrote remaining: {time.time() - start_time:.1f}s")
 
     if reference_method == ReferenceMethod.HIGH_COHERENCE:


### PR DESCRIPTION
- The fix lets you run 
```bash
uvx --with "opera-utils[disp]>=0.23.2" opera-utils disp-s1-download
```
(after release)
- Fixes missing reformat comparison test, fix `.nc` reformat