### PR TITLE
Fix CCSLC regex: Add `frame_id` to compressed cslc regex

### DIFF
--- a/src/opera_utils/constants.py
+++ b/src/opera_utils/constants.py
@@ -35,7 +35,7 @@ COMPRESSED_CSLC_S1_FILE_REGEX = (
     r"(?P<level>L2)_"
     r"(?P<is_compressed>COMPRESSED-)?"
     r"(?P<product_type>CSLC-S1)_"
-    r"(?P<frame_id>F\d+_)?"
+    r"(?P<frame_id>F\d+)?_?"
     r"(?P<burst_id>T\d{3}-\d+-IW\d)_"
     r"(?P<start_datetime>\d{8}T\d{6}Z)_"
     r"(?P<ministack_start_datetime>\d{8}T\d{6}Z)_"

--- a/src/opera_utils/constants.py
+++ b/src/opera_utils/constants.py
@@ -35,6 +35,7 @@ COMPRESSED_CSLC_S1_FILE_REGEX = (
     r"(?P<level>L2)_"
     r"(?P<is_compressed>COMPRESSED-)?"
     r"(?P<product_type>CSLC-S1)_"
+    r"(?P<frame_id>F\d+_)?"
     r"(?P<burst_id>T\d{3}-\d+-IW\d)_"
     r"(?P<start_datetime>\d{8}T\d{6}Z)_"
     r"(?P<ministack_start_datetime>\d{8}T\d{6}Z)_"

--- a/tests/test_cslc.py
+++ b/tests/test_cslc.py
@@ -87,13 +87,14 @@ def test_compass_regex():
 
 
 def test_compressed_file_regex():
-    filename = "OPERA_L2_COMPRESSED-CSLC-S1_T124-264305-IW1_20171209T000000Z_20170916T000000Z_20171209T000000Z_20250521T121130Z_VV_v1.0.h5"
+    filename = "OPERA_L2_COMPRESSED-CSLC-S1_F12345_T124-264305-IW1_20171209T000000Z_20170916T000000Z_20171209T000000Z_20250521T121130Z_VV_v1.0.h5"
     result = parse_filename(filename)
     expected = {
         "project": "OPERA",
         "level": "L2",
         "is_compressed": "COMPRESSED-",
         "product_type": "CSLC-S1",
+        "frame_id": "F12345",
         "burst_id": "t124_264305_iw1",
         "start_datetime": datetime.datetime(
             2017, 12, 9, 0, 0, tzinfo=datetime.timezone.utc
@@ -107,6 +108,12 @@ def test_compressed_file_regex():
         "product_version": "1.0",
     }
     assert result == expected
+
+    filename_old = "OPERA_L2_COMPRESSED-CSLC-S1_T124-264305-IW1_20171209T000000Z_20170916T000000Z_20171209T000000Z_20250521T121130Z_VV_v1.0.h5"
+    result2 = parse_filename(filename_old)
+    expected2 = expected.copy()
+    expected2["frame_id"] = None
+    assert result2 == expected2
 
 
 def test_get_radar_wavelength():

--- a/tests/test_disp_search.py
+++ b/tests/test_disp_search.py
@@ -101,7 +101,7 @@ def test_search_with_mock_response(cmr_response_json):
         args, kwargs = mock_get.call_args
         assert args[0] == "https://cmr.earthdata.nasa.gov/search/granules.umm_json"
         assert kwargs["params"]["short_name"] == "OPERA_L3_DISP-S1_V1"
-        assert kwargs["params"]["page_size"] == 2000
+        assert kwargs["params"]["page_size"] == 500
         assert "int,FRAME_NUMBER,11116" in kwargs["params"]["attribute[]"]
         assert "float,PRODUCT_VERSION,1.0" in kwargs["params"]["attribute[]"]
 


### PR DESCRIPTION
Fixes parsing of old-style and newer production CCSLC filenames
