### PR TITLE
Add a filter for duplicate DISP-S1 products

### DIFF
--- a/src/opera_utils/disp/_product.py
+++ b/src/opera_utils/disp/_product.py
@@ -240,7 +240,6 @@ class DispProductStack:
             for p in self.products:
                 date_pair_groups[p.reference_datetime, p.secondary_datetime].append(p)
 
-            # Filter duplicates
             filtered_products = []
             removed_count = 0
             for _date_pair, group in date_pair_groups.items():


### PR DESCRIPTION
CMR seems to have duplicates, which prevents the `DispProductStack` from being created:

```
wget https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L3_DISP-S1_V1/OPERA_L3_DISP-S1_IW_F08889_VV_20211124T002928Z_20211218T002927Z_v1.0_20251027T023406Z/OPERA_L3_DISP-S1_IW_F08889_VV_20211124T002928Z_20211218T002927Z_v1.0_20251027T023406Z.nc
wget https://cumulus.asf.earthdatacloud.nasa.gov/OPERA/OPERA_L3_DISP-S1_V1/OPERA_L3_DISP-S1_IW_F08889_VV_20211124T002928Z_20211218T002927Z_v1.0_20251026T233348Z/OPERA_L3_DISP-S1_IW_F08889_VV_20211124T002928Z_20211218T002927Z_v1.0_20251026T233348Z.nc
```

- Changed duplicate handling from raising ValueError to issuing a UserWarning
- Implemented filtering logic that keeps products with:
  - Highest version (compared lexicographically)
  - Most recent `generation_datetime` when versions are equal