### PR TITLE
Fix PR 204 review issues

### DIFF
--- a/docs/examples/nisar_gslc_interferogram.py
+++ b/docs/examples/nisar_gslc_interferogram.py
@@ -125,7 +125,7 @@ def main():
     looks_row, looks_col = calculate_square_looks(
         x_spacing, y_spacing, target_resolution=60
     )
-    print(f"Multilooking with {looks_row}x{looks_col} looks for ~100m resolution...")
+    print(f"Multilooking with {looks_row}x{looks_col} looks for ~60m resolution...")
     ifg_ml = multilook(ifg, looks_row, looks_col)
     print(f"  Multilooked shape: {ifg_ml.shape}")
 

--- a/src/opera_utils/nisar/_download.py
+++ b/src/opera_utils/nisar/_download.py
@@ -166,7 +166,9 @@ def _extract_subset_from_h5(
 
         # Get available polarizations for the frequency
         freq_path = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
-        assert freq_path in src, f"Frequency {frequency} not found"
+        if freq_path not in src:
+            msg = f"Frequency {frequency} not found in {source_name}"
+            raise ValueError(msg)
 
         available_pols = [
             name for name in src[freq_path] if name in NISAR_POLARIZATIONS
@@ -180,7 +182,9 @@ def _extract_subset_from_h5(
             if missing:
                 logger.warning(f"Polarizations not found: {missing}")
 
-        assert pols_to_extract, "No polarizations to extract"
+        if not pols_to_extract:
+            msg = f"No polarizations to extract from {source_name}"
+            raise ValueError(msg)
 
         # Create the grids structure
         dst.create_group(NISAR_GSLC_GRIDS)
@@ -395,7 +399,9 @@ def run_download(
     --------
     Download by bounding box (searches CMR and subsets to that region):
 
-    >>> run_download(bbox=(40.62, 13.56, 40.72, 13.64), polarizations=["HH"])
+    >>> run_download(  # doctest: +SKIP
+    ...     bbox=(40.62, 13.56, 40.72, 13.64), polarizations=["HH"]
+    ... )
 
     """
     # Validate mutually exclusive subsetting options

--- a/src/opera_utils/nisar/_search.py
+++ b/src/opera_utils/nisar/_search.py
@@ -113,12 +113,16 @@ def search(
     # If no temporal range is specified, set wide defaults for filtering
     if start_datetime is None:
         start_datetime = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    else:
+    elif start_datetime.tzinfo is None:
         start_datetime = start_datetime.replace(tzinfo=timezone.utc)
+    else:
+        start_datetime = start_datetime.astimezone(timezone.utc)
     if end_datetime is None:
         end_datetime = datetime(2100, 1, 1, tzinfo=timezone.utc)
-    else:
+    elif end_datetime.tzinfo is None:
         end_datetime = end_datetime.replace(tzinfo=timezone.utc)
+    else:
+        end_datetime = end_datetime.astimezone(timezone.utc)
 
     # Add attribute filters for track/frame if provided
     # CMR attribute names: TRACK_NUMBER (=relative orbit), FRAME_NUMBER (=track frame),

--- a/tests/test_nisar_product.py
+++ b/tests/test_nisar_product.py
@@ -12,12 +12,12 @@ import numpy as np
 import pyproj
 import pytest
 
+from opera_utils._cmr import get_download_url as _get_download_url
 from opera_utils.constants import NISAR_GSLC_GRIDS, UrlType
 from opera_utils.nisar._product import (
     GslcProduct,
     OrbitDirection,
     OutOfBoundsError,
-    _get_download_url,
     _to_datetime,
 )
 
@@ -303,7 +303,10 @@ class TestGetDownloadUrl:
                 {"URL": "https://example.com/file.h5", "Type": "GET DATA"},
             ]
         }
-        assert _get_download_url(umm, UrlType.HTTPS) == "https://example.com/file.h5"
+        assert (
+            _get_download_url(umm, UrlType.HTTPS, filename_suffix=".h5")
+            == "https://example.com/file.h5"
+        )
 
     def test_falls_back_to_non_h5(self):
         umm = {
@@ -311,7 +314,10 @@ class TestGetDownloadUrl:
                 {"URL": "https://example.com/file.nc", "Type": "GET DATA"},
             ]
         }
-        assert _get_download_url(umm, UrlType.HTTPS) == "https://example.com/file.nc"
+        assert (
+            _get_download_url(umm, UrlType.HTTPS, filename_suffix=".h5")
+            == "https://example.com/file.nc"
+        )
 
     def test_s3_url(self):
         umm = {

--- a/tests/test_nisar_search.py
+++ b/tests/test_nisar_search.py
@@ -64,7 +64,7 @@ class MockResponse:
 
 class TestSearch:
     def test_basic_search(self, cmr_response_json):
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(cmr_response_json)
             products = search(
                 bbox=(40.0, 13.0, 41.0, 14.0),
@@ -85,7 +85,7 @@ class TestSearch:
         """Results should be sorted by (track_frame_id, start_datetime)."""
         # Reverse the items so they arrive out of order
         cmr_response_json["items"].reverse()
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(cmr_response_json)
             products = search(bbox=(40.0, 13.0, 41.0, 14.0))
 
@@ -97,7 +97,7 @@ class TestSearch:
                 _make_umm_item(FILE_1, protocol="s3"),
             ]
         }
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(response)
             products = search(bbox=(40.0, 13.0, 41.0, 14.0), url_type=UrlType.S3)
 
@@ -106,7 +106,7 @@ class TestSearch:
 
     def test_filter_by_track_frame(self, cmr_response_json):
         """Exact track_frame match filters on the combined ID."""
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(cmr_response_json)
             products = search(
                 bbox=(40.0, 13.0, 41.0, 14.0),
@@ -125,7 +125,7 @@ class TestSearch:
                 _make_umm_item(FILE_DESC),
             ]
         }
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(response)
             products = search(bbox=(40.0, 13.0, 41.0, 14.0), orbit_direction="A")
 
@@ -134,7 +134,7 @@ class TestSearch:
 
     def test_filter_by_temporal_range(self, cmr_response_json):
         """Only products within the datetime range are returned."""
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(cmr_response_json)
             products = search(
                 bbox=(40.0, 13.0, 41.0, 14.0),
@@ -155,7 +155,7 @@ class TestSearch:
         page2_response = MockResponse(
             {"items": [_make_umm_item(FILE_2)]},
         )
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.side_effect = [page1_response, page2_response]
             products = search(bbox=(40.0, 13.0, 41.0, 14.0))
 
@@ -167,13 +167,13 @@ class TestSearch:
 
     def test_no_constraints_warning(self):
         """Warns when no spatial or orbit constraints are specified."""
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse({"items": []})
             with pytest.warns(UserWarning, match="search may be large"):
                 search()
 
     def test_empty_results(self):
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse({"items": []})
             products = search(bbox=(0.0, 0.0, 1.0, 1.0))
 
@@ -181,7 +181,7 @@ class TestSearch:
 
     def test_attribute_filters_in_params(self):
         """CMR attribute filters are built for orbit parameters."""
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse({"items": []})
             search(
                 relative_orbit_number=76,
@@ -197,7 +197,7 @@ class TestSearch:
 
     def test_temporal_param_in_request(self):
         """Start/end datetime is sent to CMR as temporal parameter."""
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse({"items": []})
             search(
                 bbox=(0, 0, 1, 1),
@@ -222,7 +222,7 @@ class TestSearch:
                 _make_umm_item(FILE_1),
             ]
         }
-        with patch("opera_utils.nisar._search.requests.get") as mock_get:
+        with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(response)
             products = search(bbox=(40.0, 13.0, 41.0, 14.0))
 


### PR DESCRIPTION
test imports, monkeypatch paths, assertion and timezone handling

- Replace assert statements with ValueError in _download.py (stripped by python -O)
- Fix timezone handling in _search.py to preserve tz-aware datetimes
- Fix test monkeypatch paths: opera_utils.nisar._remote -> opera_utils._remote
- Fix test mock paths: opera_utils.nisar._search.requests -> opera_utils._cmr.requests
- Fix test import: _get_download_url moved to opera_utils._cmr.get_download_url
- Fix mock lambda signatures to accept keyword args (host, asf_endpoint)
- Fix docstring resolution mismatch (100m -> 60m) in example
- Add doctest: +SKIP to run_download example requiring credentials