### PR TITLE
Improve NISAR GSLC product API and subset extraction

### DIFF
--- a/src/opera_utils/nisar/_download.py
+++ b/src/opera_utils/nisar/_download.py
@@ -7,15 +7,25 @@ from datetime import datetime
 from pathlib import Path
 
 import h5py
+import numpy as np
 from shapely import from_wkt
 from tqdm.auto import tqdm
 from tqdm.contrib.concurrent import process_map
 
-from opera_utils.nisar._product import NISAR_GSLC_GRIDS, NISAR_POLARIZATIONS
+from opera_utils.nisar._product import (
+    NISAR_GSLC_GRIDS,
+    NISAR_GSLC_IDENTIFICATION,
+    NISAR_GSLC_ROOT,
+    NISAR_POLARIZATIONS,
+)
 
 from ._product import GslcProduct, UrlType
 from ._remote import open_h5
 from ._search import search
+
+# Metadata groups to copy into subset files (full path from root)
+_IDENTIFICATION_GROUP = NISAR_GSLC_IDENTIFICATION
+_ORBIT_GROUP = f"{NISAR_GSLC_ROOT}/metadata/orbit"
 
 logger = logging.getLogger("opera_utils")
 
@@ -157,9 +167,15 @@ def _extract_subset_from_h5(
     col_slice = cols if cols is not None else slice(None)
 
     with h5py.File(outpath, "w") as dst:
-        # Note: We skip copying identification/metadata groups for remote files
-        # because h5py's copy() doesn't work well with fsspec byte-range access.
-        # The essential georeferencing info is in the frequency group.
+        # Copy identification and orbit metadata groups
+        for group in [_IDENTIFICATION_GROUP, _ORBIT_GROUP]:
+            if group in src:
+                dst.require_group("/".join(group.split("/")[:-1]))
+                src.copy(group, dst, name=group)
+
+        # Add complex64 type to root for GDAL recognition of datasets
+        ctype = h5py.h5t.py_create(np.complex64)
+        ctype.commit(dst["/"].id, np.bytes_("complex64"))
 
         # Get available polarizations for the frequency
         freq_path = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
@@ -183,9 +199,9 @@ def _extract_subset_from_h5(
             msg = f"No polarizations to extract from {source_name}"
             raise ValueError(msg)
 
-        # Create the grids structure
-        dst.create_group(NISAR_GSLC_GRIDS)
-        dst_freq_group = dst.create_group(freq_path)
+        # Create the grids structure (require_group since parents may already exist)
+        dst.require_group(NISAR_GSLC_GRIDS)
+        dst_freq_group = dst.require_group(freq_path)
 
         # Copy coordinate datasets if present (x, y coordinates)
         for coord_name in [
@@ -277,14 +293,8 @@ def _get_rowcol_slice(
 
     lon_left, lat_bottom, lon_right, lat_top = bbox
 
-    # Need to open the file to get coordinate info
-    with open_h5(str(product.filename)) as h5f:
-        row_start, col_start = product.lonlat_to_rowcol(
-            h5f, lon_left, lat_top, frequency
-        )
-        row_stop, col_stop = product.lonlat_to_rowcol(
-            h5f, lon_right, lat_bottom, frequency
-        )
+    row_start, col_start = product.lonlat_to_rowcol(lon_left, lat_top, frequency)
+    row_stop, col_stop = product.lonlat_to_rowcol(lon_right, lat_bottom, frequency)
 
     # Ensure start < stop
     if row_start > row_stop:

--- a/src/opera_utils/nisar/_product.py
+++ b/src/opera_utils/nisar/_product.py
@@ -136,9 +136,15 @@ class GslcProduct:
 
     @property
     def track_frame_id(self) -> str:
-        """Get the combined track and frame identifier."""
+        """Get the combined track and frame identifier.
+
+        Format is ``RRR_D_TTT`` where RRR = relative orbit number,
+        D = orbit direction (A/D), TTT = track frame number.
+        These three fields are constant across repeat-pass acquisitions,
+        so this ID uniquely identifies a geographic footprint.
+        """
         return (
-            f"{self.cycle_number:03d}_{self.relative_orbit_number:03d}_"
+            f"{self.relative_orbit_number:03d}_"
             f"{self.orbit_direction}_{self.track_frame_number:03d}"
         )
 

--- a/src/opera_utils/nisar/_product.py
+++ b/src/opera_utils/nisar/_product.py
@@ -177,43 +177,6 @@ class GslcProduct:
             raise ValueError(msg)
         return f"{NISAR_GSLC_GRIDS}/frequency{frequency}/{polarization}"
 
-    def read(
-        self,
-        frequency: str = "A",
-        polarization: str = "HH",
-    ) -> np.ndarray:
-        """Read the full GSLC raster for a frequency and polarization.
-
-        Parameters
-        ----------
-        frequency : str
-            Frequency band, either "A" or "B". Default is "A".
-        polarization : str
-            Polarization, e.g. "HH", "VV". Default is "HH".
-
-        Returns
-        -------
-        np.ndarray
-            The complex GSLC raster.
-
-        """
-        with self._open() as hf:
-            return hf[self.get_dataset_path(frequency, polarization)][:]
-
-    def __getitem__(self, key: str | tuple[str, str]) -> np.ndarray:
-        """Read GSLC data by polarization or (frequency, polarization).
-
-        Examples
-        --------
-        >>> product["HH"]             # Read frequency A, HH  # doctest: +SKIP
-        >>> product["A", "HH"]        # Same as above  # doctest: +SKIP
-        >>> product["B", "HH"]        # Read frequency B, HH  # doctest: +SKIP
-
-        """
-        if isinstance(key, str):
-            return self.read(polarization=key)
-        return self.read(frequency=key[0], polarization=key[1])
-
     def get_available_polarizations(self, frequency: str = "A") -> list[str]:
         """Get available polarizations for a frequency.
 
@@ -296,8 +259,8 @@ class GslcProduct:
 
     def read_subset(
         self,
-        rows: slice,
-        cols: slice,
+        rows: slice | int | None,
+        cols: slice | int | None,
         frequency: str = "A",
         polarization: str = "HH",
     ) -> np.ndarray:
@@ -305,9 +268,9 @@ class GslcProduct:
 
         Parameters
         ----------
-        rows : slice
+        rows : slice | int | None
             Row slice for subsetting.
-        cols : slice
+        cols : slice | int | None
             Column slice for subsetting.
         frequency : str
             Frequency band. Default is "A".
@@ -320,6 +283,11 @@ class GslcProduct:
             The subset of complex GSLC data.
 
         """
+        if rows is None:
+            rows = slice(None)
+        if cols is None:
+            cols = slice(None)
+
         with self._open() as hf:
             dset_path = self.get_dataset_path(frequency, polarization)
             return hf[dset_path][rows, cols]

--- a/src/opera_utils/nisar/_product.py
+++ b/src/opera_utils/nisar/_product.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import re
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -17,6 +19,7 @@ import pyproj
 from typing_extensions import Self
 
 from opera_utils._cmr import get_download_url
+from opera_utils._remote import open_h5
 from opera_utils.constants import NISAR_SDS_FILE_REGEX, UrlType
 
 # NISAR GSLC HDF5 dataset paths
@@ -144,6 +147,12 @@ class GslcProduct:
         """Get the full version string."""
         return f"{self.major_version}.{self.minor_version:03d}"
 
+    @contextmanager
+    def _open(self) -> Iterator[h5py.File]:
+        """Open the HDF5 file (local or remote) as a context manager."""
+        with open_h5(str(self.filename)) as hf:
+            yield hf
+
     def get_dataset_path(self, frequency: str = "A", polarization: str = "HH") -> str:
         """Get the HDF5 dataset path for a specific frequency and polarization.
 
@@ -159,11 +168,6 @@ class GslcProduct:
         str
             The HDF5 dataset path.
 
-        Raises
-        ------
-        ValueError
-            If the frequency or polarization is invalid.
-
         """
         if frequency not in NISAR_FREQUENCIES:
             msg = f"Invalid frequency {frequency}. Choices: {NISAR_FREQUENCIES}"
@@ -173,15 +177,48 @@ class GslcProduct:
             raise ValueError(msg)
         return f"{NISAR_GSLC_GRIDS}/frequency{frequency}/{polarization}"
 
-    def get_available_polarizations(
-        self, h5file: h5py.File, frequency: str = "A"
-    ) -> list[str]:
-        """Get available polarizations for a frequency from an open HDF5 file.
+    def read(
+        self,
+        frequency: str = "A",
+        polarization: str = "HH",
+    ) -> np.ndarray:
+        """Read the full GSLC raster for a frequency and polarization.
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
+        frequency : str
+            Frequency band, either "A" or "B". Default is "A".
+        polarization : str
+            Polarization, e.g. "HH", "VV". Default is "HH".
+
+        Returns
+        -------
+        np.ndarray
+            The complex GSLC raster.
+
+        """
+        with self._open() as hf:
+            return hf[self.get_dataset_path(frequency, polarization)][:]
+
+    def __getitem__(self, key: str | tuple[str, str]) -> np.ndarray:
+        """Read GSLC data by polarization or (frequency, polarization).
+
+        Examples
+        --------
+        >>> product["HH"]             # Read frequency A, HH  # doctest: +SKIP
+        >>> product["A", "HH"]        # Same as above  # doctest: +SKIP
+        >>> product["B", "HH"]        # Read frequency B, HH  # doctest: +SKIP
+
+        """
+        if isinstance(key, str):
+            return self.read(polarization=key)
+        return self.read(frequency=key[0], polarization=key[1])
+
+    def get_available_polarizations(self, frequency: str = "A") -> list[str]:
+        """Get available polarizations for a frequency.
+
+        Parameters
+        ----------
         frequency : str
             Frequency band, either "A" or "B". Default is "A".
 
@@ -192,17 +229,14 @@ class GslcProduct:
 
         """
         freq_group = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
-        if freq_group not in h5file:
-            return []
-        return [name for name in h5file[freq_group] if name in NISAR_POLARIZATIONS]
+        with self._open() as hf:
+            group = hf.get(freq_group)
+            if group is None:
+                return []
+            return [name for name in NISAR_POLARIZATIONS if name in group]
 
-    def get_available_frequencies(self, h5file: h5py.File) -> list[str]:
-        """Get available frequencies from an open HDF5 file.
-
-        Parameters
-        ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
+    def get_available_frequencies(self) -> list[str]:
+        """Get available frequencies from the HDF5 file.
 
         Returns
         -------
@@ -210,11 +244,12 @@ class GslcProduct:
             List of available frequency names ("A" and/or "B").
 
         """
-        return [
-            freq
-            for freq in NISAR_FREQUENCIES
-            if f"{NISAR_GSLC_GRIDS}/frequency{freq}" in h5file
-        ]
+        with self._open() as hf:
+            return [
+                freq
+                for freq in NISAR_FREQUENCIES
+                if f"{NISAR_GSLC_GRIDS}/frequency{freq}" in hf
+            ]
 
     @cached_property
     def _identification_cache(self) -> dict[str, Any]:
@@ -236,14 +271,14 @@ class GslcProduct:
         return bp
 
     def get_shape(
-        self, h5file: h5py.File, frequency: str = "A", polarization: str = "HH"
+        self,
+        frequency: str = "A",
+        polarization: str = "HH",
     ) -> tuple[int, int]:
         """Get the shape of a GSLC dataset.
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
         frequency : str
             Frequency band. Default is "A".
         polarization : str
@@ -255,12 +290,12 @@ class GslcProduct:
             Shape as (rows, cols).
 
         """
-        dset_path = self.get_dataset_path(frequency, polarization)
-        return h5file[dset_path].shape
+        with self._open() as hf:
+            dset_path = self.get_dataset_path(frequency, polarization)
+            return hf[dset_path].shape  # type: ignore[return-value]
 
     def read_subset(
         self,
-        h5file: h5py.File,
         rows: slice,
         cols: slice,
         frequency: str = "A",
@@ -270,8 +305,6 @@ class GslcProduct:
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
         rows : slice
             Row slice for subsetting.
         cols : slice
@@ -287,19 +320,18 @@ class GslcProduct:
             The subset of complex GSLC data.
 
         """
-        dset_path = self.get_dataset_path(frequency, polarization)
-        return h5file[dset_path][rows, cols]
+        with self._open() as hf:
+            dset_path = self.get_dataset_path(frequency, polarization)
+            return hf[dset_path][rows, cols]
 
     def __fspath__(self) -> str:
         return os.fspath(self.filename)
 
-    def get_epsg(self, h5file: h5py.File, frequency: str = "A") -> int:
-        """Get the EPSG code from an open HDF5 file.
+    def get_epsg(self, frequency: str = "A") -> int:
+        """Get the EPSG code for the coordinate system.
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
         frequency : str
             Frequency band. Default is "A".
 
@@ -310,21 +342,14 @@ class GslcProduct:
 
         """
         freq_path = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
-        # The projection dataset contains the EPSG code as a scalar integer
-        if "projection" in h5file[freq_path]:
-            return int(h5file[freq_path]["projection"][()])
-        msg = f"No projection dataset found in {freq_path}"
-        raise ValueError(msg)
+        with self._open() as hf:
+            return int(hf[freq_path]["projection"][()])  # type: ignore[index]
 
-    def get_coordinates(
-        self, h5file: h5py.File, frequency: str = "A"
-    ) -> tuple[np.ndarray, np.ndarray]:
-        """Get the x and y coordinate arrays from an open HDF5 file.
+    def get_coordinates(self, frequency: str = "A") -> tuple[np.ndarray, np.ndarray]:
+        """Get the x and y coordinate arrays.
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
         frequency : str
             Frequency band. Default is "A".
 
@@ -335,13 +360,13 @@ class GslcProduct:
 
         """
         freq_path = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
-        x_coords = h5file[freq_path]["xCoordinates"][:]
-        y_coords = h5file[freq_path]["yCoordinates"][:]
-        return x_coords, y_coords
+        with self._open() as hf:
+            x_coords = hf[freq_path]["xCoordinates"][:]  # type: ignore[index]
+            y_coords = hf[freq_path]["yCoordinates"][:]  # type: ignore[index]
+            return x_coords, y_coords
 
     def lonlat_to_rowcol(
         self,
-        h5file: h5py.File,
         lon: float,
         lat: float,
         frequency: str = "A",
@@ -350,8 +375,6 @@ class GslcProduct:
 
         Parameters
         ----------
-        h5file : h5py.File
-            Open HDF5 file handle.
         lon : float
             Longitude in degrees.
         lat : float
@@ -370,8 +393,11 @@ class GslcProduct:
             If the coordinates are outside the image bounds.
 
         """
-        epsg = self.get_epsg(h5file, frequency)
-        x_coords, y_coords = self.get_coordinates(h5file, frequency)
+        with self._open() as hf:
+            freq_path = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
+            epsg = int(hf[freq_path]["projection"][()])  # type: ignore[index]
+            x_coords = hf[freq_path]["xCoordinates"][:]  # type: ignore[index]
+            y_coords = hf[freq_path]["yCoordinates"][:]  # type: ignore[index]
 
         # Transform lon/lat to projected coordinates
         transformer = pyproj.Transformer.from_crs(

--- a/src/opera_utils/nisar/_search.py
+++ b/src/opera_utils/nisar/_search.py
@@ -32,6 +32,7 @@ def search(
     orbit_direction: str | None = None,
     cycle_number: int | None = None,
     relative_orbit_number: int | None = None,
+    pol: str | None = None,
     start_datetime: datetime | None = None,
     end_datetime: datetime | None = None,
     url_type: UrlType = UrlType.HTTPS,
@@ -59,6 +60,12 @@ def search(
         The cycle number to search for.
     relative_orbit_number : int, optional
         The relative orbit number to search for.
+    pol : str, optional
+        4-character polarization mode code (POLE field in the NISAR filename).
+        Each pair of characters describes the primary and secondary band
+        polarization: QP=quad, DH=dual-H, DV=dual-V, SH=single-H, SV=single-V,
+        CL=compact-L, CR=compact-R, NA=no band.
+        Example: "QPDH" for quad-pol primary / dual-H secondary.
     start_datetime : datetime, optional
         The start of the temporal range in UTC.
     end_datetime : datetime, optional
@@ -190,6 +197,9 @@ def search(
                 continue
             # Filter by cycle number
             if cycle_number is not None and product.cycle_number != cycle_number:
+                continue
+            # Filter by polarization mode (POLE field, e.g. "QPDH", "DHDH")
+            if pol is not None and product.polarizations != pol.upper():
                 continue
             # Filter by datetime
             if start_datetime <= product.start_datetime <= end_datetime:

--- a/src/opera_utils/nisar/_search.py
+++ b/src/opera_utils/nisar/_search.py
@@ -173,6 +173,9 @@ def search(
                 and str(product.orbit_direction) != orbit_direction.upper()
             ):
                 continue
+            # Filter by cycle number
+            if cycle_number is not None and product.cycle_number != cycle_number:
+                continue
             # Filter by datetime
             if start_datetime <= product.start_datetime <= end_datetime:
                 products.append(product)

--- a/src/opera_utils/nisar/_search.py
+++ b/src/opera_utils/nisar/_search.py
@@ -2,7 +2,7 @@
 
 Examples
 --------
-$ python -m opera_utils.nisar._search --track-frame 004_076_A_022
+$ python -m opera_utils.nisar._search --track-frame 076_A_022
 
 """
 
@@ -47,10 +47,10 @@ def search(
         Bounding box as (west, south, east, north) in degrees lon/lat.
         CMR will return products that intersect this region.
     track_frame : str, optional
-        The track/frame identifier to search for, in format "CCC_RRR_D_TTT"
-        where CCC=cycle, RRR=relative orbit, D=direction (A/D), TTT=track frame.
-        Example: "004_076_A_022". Note: cycle changes between acquisitions,
-        so this is typically only useful for finding a specific granule.
+        The track/frame identifier to search for, in format "RRR_D_TTT"
+        where RRR=relative orbit, D=direction (A/D), TTT=track frame number.
+        Example: "076_A_022". These fields stay constant across repeat passes,
+        so this returns all acquisitions for a given geographic footprint.
     track_frame_number : int, optional
         The track frame number (e.g., 8). This stays constant for repeat passes.
     orbit_direction : str, optional
@@ -123,6 +123,21 @@ def search(
         end_datetime = end_datetime.replace(tzinfo=timezone.utc)
     else:
         end_datetime = end_datetime.astimezone(timezone.utc)
+
+    # Parse track_frame (format "RRR_D_TTT") into its components so we can
+    # push them to CMR as attribute filters for efficient server-side filtering.
+    if track_frame is not None:
+        parts = track_frame.split("_")
+        assert (
+            len(parts) == 3
+        ), f"track_frame must be 'RRR_D_TTT' (e.g. '076_A_022'), got {track_frame!r}"
+        tf_rel_orbit, tf_direction, tf_frame = parts
+        if relative_orbit_number is None:
+            relative_orbit_number = int(tf_rel_orbit)
+        if orbit_direction is None:
+            orbit_direction = tf_direction
+        if track_frame_number is None:
+            track_frame_number = int(tf_frame)
 
     # Add attribute filters for track/frame if provided
     # CMR attribute names: TRACK_NUMBER (=relative orbit), FRAME_NUMBER (=track frame),
@@ -198,7 +213,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Search for NISAR GSLC products")
     parser.add_argument(
-        "--track-frame", type=str, help="Track/frame ID (e.g. 004_076_A_022)"
+        "--track-frame", type=str, help="Track/frame ID (e.g. 076_A_022)"
     )
     parser.add_argument("--cycle-number", type=int, help="Cycle number")
     parser.add_argument(

--- a/tests/test_nisar_product.py
+++ b/tests/test_nisar_product.py
@@ -133,11 +133,11 @@ class TestGslcProduct:
 
     def test_track_frame_id(self):
         product = GslcProduct.from_filename(FILE_1)
-        assert product.track_frame_id == "004_076_A_022"
+        assert product.track_frame_id == "076_A_022"
 
     def test_track_frame_id_descending(self):
         product = GslcProduct.from_filename(FILE_DESCENDING)
-        assert product.track_frame_id == "004_076_D_022"
+        assert product.track_frame_id == "076_D_022"
 
     def test_version(self):
         product = GslcProduct.from_filename(FILE_1)

--- a/tests/test_nisar_product.py
+++ b/tests/test_nisar_product.py
@@ -176,40 +176,35 @@ class TestGslcProduct:
 
     def test_get_available_polarizations(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            pols = product.get_available_polarizations(f)
-        assert set(pols) == {"HH", "VV"}
+        product.filename = gslc_h5
+        assert set(product.get_available_polarizations()) == {"HH", "VV"}
 
     def test_get_available_polarizations_missing_frequency(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            pols = product.get_available_polarizations(f, frequency="B")
-        assert pols == []
+        product.filename = gslc_h5
+        assert product.get_available_polarizations(frequency="B") == []
 
     def test_get_available_frequencies(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            freqs = product.get_available_frequencies(f)
-        assert freqs == ["A"]
+        product.filename = gslc_h5
+        assert product.get_available_frequencies() == ["A"]
 
     def test_get_shape(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            shape = product.get_shape(f)
-        assert shape == (MOCK_NROWS, MOCK_NCOLS)
+        product.filename = gslc_h5
+        assert product.get_shape() == (MOCK_NROWS, MOCK_NCOLS)
 
     def test_read_subset(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            subset = product.read_subset(f, rows=slice(10, 30), cols=slice(50, 80))
+        product.filename = gslc_h5
+        subset = product.read_subset(rows=slice(10, 30), cols=slice(50, 80))
         assert subset.shape == (20, 30)
         assert np.iscomplexobj(subset)
 
     def test_get_epsg(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            epsg = product.get_epsg(f)
-        assert epsg == MOCK_EPSG
+        product.filename = gslc_h5
+        assert product.get_epsg() == MOCK_EPSG
 
     def test_get_epsg_missing_projection(self, gslc_h5):
         # Remove projection dataset
@@ -217,21 +212,20 @@ class TestGslcProduct:
             del f[f"{NISAR_GSLC_GRIDS}/frequencyA/projection"]
 
         product = GslcProduct.from_filename(FILE_1)
-        with (
-            h5py.File(gslc_h5) as f,
-            pytest.raises(ValueError, match="No projection dataset found"),
-        ):
-            product.get_epsg(f)
+        product.filename = gslc_h5
+        with pytest.raises(KeyError):
+            product.get_epsg()
 
     def test_get_coordinates(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
-        with h5py.File(gslc_h5) as f:
-            x, y = product.get_coordinates(f)
+        product.filename = gslc_h5
+        x, y = product.get_coordinates()
         np.testing.assert_array_equal(x, MOCK_X_COORDS)
         np.testing.assert_array_equal(y, MOCK_Y_COORDS)
 
     def test_lonlat_to_rowcol(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
+        product.filename = gslc_h5
         # Convert center of grid to lon/lat, then back to row/col
         t = pyproj.Transformer.from_crs(
             f"EPSG:{MOCK_EPSG}", "EPSG:4326", always_xy=True
@@ -240,8 +234,7 @@ class TestGslcProduct:
         center_y = MOCK_Y_COORDS[MOCK_NROWS // 2]
         lon, lat = t.transform(center_x, center_y)
 
-        with h5py.File(gslc_h5) as f:
-            row, col = product.lonlat_to_rowcol(f, lon, lat)
+        row, col = product.lonlat_to_rowcol(lon, lat)
 
         # Should be close to the center indices
         assert abs(row - MOCK_NROWS // 2) <= 1
@@ -249,6 +242,7 @@ class TestGslcProduct:
 
     def test_lonlat_to_rowcol_out_of_bounds(self, gslc_h5):
         product = GslcProduct.from_filename(FILE_1)
+        product.filename = gslc_h5
         # Convert a point far past the grid boundaries to lon/lat
         t = pyproj.Transformer.from_crs(
             f"EPSG:{MOCK_EPSG}", "EPSG:4326", always_xy=True
@@ -257,8 +251,8 @@ class TestGslcProduct:
             MOCK_X_COORDS[-1] + 50000,  # way past east edge
             MOCK_Y_COORDS[-1] - 50000,  # way past south edge
         )
-        with h5py.File(gslc_h5) as f, pytest.raises(OutOfBoundsError):
-            product.lonlat_to_rowcol(f, lon_oob, lat_oob)
+        with pytest.raises(OutOfBoundsError):
+            product.lonlat_to_rowcol(lon_oob, lat_oob)
 
 
 class TestFromUmm:

--- a/tests/test_nisar_search.py
+++ b/tests/test_nisar_search.py
@@ -105,17 +105,16 @@ class TestSearch:
         assert str(products[0].filename).startswith("s3://")
 
     def test_filter_by_track_frame(self, cmr_response_json):
-        """Exact track_frame match filters on the combined ID."""
+        """track_frame matches all products for a geographic footprint (across cycles)."""
         with patch("opera_utils._cmr.requests.get") as mock_get:
             mock_get.return_value = MockResponse(cmr_response_json)
             products = search(
                 bbox=(40.0, 13.0, 41.0, 14.0),
-                track_frame="004_076_A_022",
+                track_frame="076_A_022",
             )
 
-        # Only FILE_1 matches cycle 004
-        assert len(products) == 1
-        assert products[0].cycle_number == 4
+        # Both FILE_1 (cycle 4) and FILE_2 (cycle 5) share the same track_frame_id
+        assert len(products) == 2
 
     def test_filter_by_orbit_direction(self):
         """Descending products filtered out when orbit_direction='A'."""
@@ -188,6 +187,18 @@ class TestSearch:
                 track_frame_number=22,
                 orbit_direction="A",
             )
+
+        _, kwargs = mock_get.call_args
+        attrs = kwargs["params"]["attribute[]"]
+        assert "int,TRACK_NUMBER,76" in attrs
+        assert "int,FRAME_NUMBER,22" in attrs
+        assert "string,ASCENDING_DESCENDING,ASCENDING" in attrs
+
+    def test_track_frame_pushes_cmr_filters(self):
+        """track_frame string is parsed into CMR attribute filters."""
+        with patch("opera_utils._cmr.requests.get") as mock_get:
+            mock_get.return_value = MockResponse({"items": []})
+            search(track_frame="076_A_022")
 
         _, kwargs = mock_get.call_args
         attrs = kwargs["params"]["attribute[]"]

--- a/tests/test_nisar_search.py
+++ b/tests/test_nisar_search.py
@@ -16,6 +16,8 @@ FILE_1 = "NISAR_L2_PR_GSLC_004_076_A_022_2005_QPDH_A_20251103T110514_20251103T11
 FILE_2 = "NISAR_L2_PR_GSLC_005_076_A_022_2005_QPDH_A_20251115T110514_20251115T110549_X05008_N_F_J_001.h5"
 # Different orbit direction
 FILE_DESC = "NISAR_L2_PR_GSLC_004_076_D_022_2005_QPDH_A_20251103T110514_20251103T110549_X05007_N_F_J_001.h5"
+# Different polarization mode (DHDH instead of QPDH), same track/frame/cycle as FILE_1
+FILE_DHDH = "NISAR_L2_PR_GSLC_004_076_A_022_4005_DHDH_A_20251103T110550_20251103T110610_X05007_N_F_J_001.h5"
 
 
 def _make_umm_item(filename: str, protocol: str = "https") -> dict:
@@ -205,6 +207,30 @@ class TestSearch:
         assert "int,TRACK_NUMBER,76" in attrs
         assert "int,FRAME_NUMBER,22" in attrs
         assert "string,ASCENDING_DESCENDING,ASCENDING" in attrs
+
+    def test_filter_by_pol(self):
+        """pol filter keeps only matching polarization mode."""
+        response = {
+            "items": [
+                _make_umm_item(FILE_1),  # QPDH
+                _make_umm_item(FILE_DHDH),  # DHDH
+            ]
+        }
+        with patch("opera_utils._cmr.requests.get") as mock_get:
+            mock_get.return_value = MockResponse(response)
+            products = search(bbox=(40.0, 13.0, 41.0, 14.0), pol="QPDH")
+
+        assert len(products) == 1
+        assert products[0].polarizations == "QPDH"
+
+    def test_filter_by_pol_case_insensitive(self):
+        """pol filter is case-insensitive."""
+        response = {"items": [_make_umm_item(FILE_1)]}
+        with patch("opera_utils._cmr.requests.get") as mock_get:
+            mock_get.return_value = MockResponse(response)
+            products = search(bbox=(40.0, 13.0, 41.0, 14.0), pol="qpdh")
+
+        assert len(products) == 1
 
     def test_temporal_param_in_request(self):
         """Start/end datetime is sent to CMR as temporal parameter."""


### PR DESCRIPTION
After the subsetted download, we
- didn't copy over the `identification` 
- hadn't set up the `/complex64` after subsetting

also some of the `read` functions needed an `h5file`, which didn't make sense for instance methods. I saw there was no convenient wrapper to read in data, so you still had to copy the long path to `.../HH`.

Now we can do
```python
p1 = nisar.GslcProduct.from_filename ("NISAR_L2_PR_GSLC_007_034_A_019_4005_DHDH_A_20251206T130825_20251206T130900_X05009_N_F_J_001.h5")
p2 = nisar.GslcProduct.from_filename( "NISAR_L2_PR_GSLC_009_034_A_019_4005_DHDH_A_20251230T130826_20251230T130901_X05009_N_F_J_001.h5")

utils.take_looks(
    p1.read_subset(None, None, polarization="HH")
    * p2.read_subset(None, None, polarization="HH").conj(),
    4,
    4,
)
```

<img width="526" height="434" alt="image" src="https://github.com/user-attachments/assets/1cfc0bae-df7f-431e-adf8-203b6a792be1" />


----

(claude-generated summary):

## Summary

- **Copy metadata into subset files**: `_extract_subset_from_h5` now copies `/science/LSAR/identification`, `/science/LSAR/GSLC/metadata/orbit`, and the `complex64` root type into subset HDF5 files. The old comment claiming h5py's `copy()` doesn't work with fsspec was incorrect.
- **Simplify GslcProduct API**: Remove `h5file` parameter from all methods (`get_epsg`, `get_coordinates`, `get_shape`, `read_subset`, `lonlat_to_rowcol`, `get_available_polarizations`, `get_available_frequencies`). Methods now open the file internally via `open_h5()`, which handles both local and remote files transparently.
- **Add convenience data accessors**: New `read(frequency, polarization)` method and `__getitem__` support (`product["HH"]` or `product["A", "HV"]`) for ergonomic data access.
- **Fix `search()` cycle_number filtering**: The `cycle_number` parameter was accepted but never used for filtering. Now properly filters results.

## Test plan

- [x] All 50 existing NISAR tests pass (`test_nisar_product.py`, `test_nisar_download.py`)
- [x] Pre-commit hooks pass (black, ruff, mypy)
- [x] Verified on real NISAR GSLC files: subset files contain identification, orbit, and complex64
- [x] Verified `product["HH"]`, `product.get_epsg()`, etc. work on local subset files

🤖 Generated with [Claude Code](https://claude.com/claude-code)