### PR TITLE
Add radar wavelength reader for NISAR GSLC products

### DIFF
--- a/src/opera_utils/nisar/__init__.py
+++ b/src/opera_utils/nisar/__init__.py
@@ -23,6 +23,7 @@ from ._product import (
 )
 from ._remote import open_file, open_h5
 from ._search import search
+from ._wavelength import get_nisar_wavelength
 
 __all__ = [
     "GslcProduct",
@@ -36,6 +37,7 @@ __all__ = [
     "get_gslc_mask",
     "get_gunw_mask",
     "get_nisar_bbox",
+    "get_nisar_wavelength",
     "load_gpkg",
     "nisar_frame_info",
     "open_file",

--- a/src/opera_utils/nisar/_product.py
+++ b/src/opera_utils/nisar/_product.py
@@ -20,7 +20,14 @@ from typing_extensions import Self
 
 from opera_utils._cmr import get_download_url
 from opera_utils._remote import open_h5
-from opera_utils.constants import NISAR_GUNW_FILE_REGEX, NISAR_SDS_FILE_REGEX, UrlType
+from opera_utils.constants import (
+    NISAR_GUNW_FILE_REGEX,
+    NISAR_SDS_FILE_REGEX,
+    SPEED_OF_LIGHT,
+    UrlType,
+)
+
+from ._wavelength import _read_center_frequency
 
 # NISAR GSLC HDF5 dataset paths
 NISAR_GSLC_ROOT = "/science/LSAR/GSLC"
@@ -364,6 +371,33 @@ class GslcProduct:
                 for freq in NISAR_FREQUENCIES
                 if f"{NISAR_GSLC_GRIDS}/frequency{freq}" in hf
             ]
+
+    def get_wavelength(self, frequency: str = "A") -> float:
+        """Get the radar wavelength for a frequency band.
+
+        Parameters
+        ----------
+        frequency : str
+            Frequency band, either "A" or "B". Default is "A".
+
+        Returns
+        -------
+        float
+            Radar wavelength in meters, computed from the frequency group's
+            ``centerFrequency``.
+
+        Raises
+        ------
+        ValueError
+            If `frequency` is invalid, or if ``centerFrequency`` is missing
+            or is not a positive, finite, real-valued scalar.
+
+        """
+        if frequency not in NISAR_FREQUENCIES:
+            msg = f"Invalid frequency {frequency}. Choices: {NISAR_FREQUENCIES}"
+            raise ValueError(msg)
+        freq_group = f"{NISAR_GSLC_GRIDS}/frequency{frequency}"
+        return SPEED_OF_LIGHT / _read_center_frequency(self.filename, freq_group)
 
     @cached_property
     def _identification_cache(self) -> dict[str, Any]:

--- a/src/opera_utils/nisar/_wavelength.py
+++ b/src/opera_utils/nisar/_wavelength.py
@@ -59,7 +59,7 @@ def _get_frequency_group_path(subdataset: str) -> str:
     matches = list(_FREQUENCY_GROUP_REGEX.finditer(subdataset))
     if len(matches) != 1:
         msg = (
-            f"Expected exactly one 'frequencyA' or 'frequencyB' path segment in"
+            "Expected exactly one 'frequencyA' or 'frequencyB' path segment in"
             f" subdataset {subdataset!r}, found {len(matches)}"
         )
         raise ValueError(msg)

--- a/src/opera_utils/nisar/_wavelength.py
+++ b/src/opera_utils/nisar/_wavelength.py
@@ -1,0 +1,111 @@
+"""Radar wavelength extraction for NISAR GSLC products."""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+
+from opera_utils._remote import open_h5
+from opera_utils._types import PathOrStr
+from opera_utils.constants import SPEED_OF_LIGHT
+
+__all__ = ["get_nisar_wavelength"]
+
+CENTER_FREQUENCY_DATASET = "centerFrequency"
+
+# Match a full "frequencyA"/"frequencyB" path segment (not a substring of a
+# longer segment name).
+_FREQUENCY_GROUP_REGEX = re.compile(r"(?:^|/)frequency[AB](?=/|$)")
+
+
+def get_nisar_wavelength(filename: PathOrStr, subdataset: str) -> float:
+    """Get the radar wavelength for one frequency group of a NISAR GSLC product.
+
+    The frequency group is located from `subdataset`, so the wavelength always
+    corresponds to the same radar band and frequency sub-band as the data being
+    processed (e.g. the subdataset ``/science/LSAR/GSLC/grids/frequencyA/HH``
+    reads ``/science/LSAR/GSLC/grids/frequencyA/centerFrequency``).
+
+    Parameters
+    ----------
+    filename : PathOrStr
+        Path or URL of the NISAR GSLC HDF5 file.
+        Remote (HTTPS/S3) URLs are opened via `opera_utils.open_h5`.
+    subdataset : str
+        HDF5 path to the dataset being processed, or to its frequency group.
+        Must contain exactly one ``frequencyA`` or ``frequencyB`` path segment.
+
+    Returns
+    -------
+    float
+        Radar wavelength in meters, computed as the speed of light divided by
+        the frequency group's ``centerFrequency``.
+
+    Raises
+    ------
+    ValueError
+        If `subdataset` does not contain exactly one frequency group segment,
+        or if ``centerFrequency`` is missing or is not a positive, finite,
+        real-valued scalar.
+
+    """
+    group_path = _get_frequency_group_path(subdataset)
+    return SPEED_OF_LIGHT / _read_center_frequency(filename, group_path)
+
+
+def _get_frequency_group_path(subdataset: str) -> str:
+    """Extract the path up to the frequency group from a subdataset path."""
+    matches = list(_FREQUENCY_GROUP_REGEX.finditer(subdataset))
+    if len(matches) != 1:
+        msg = (
+            f"Expected exactly one 'frequencyA' or 'frequencyB' path segment in"
+            f" subdataset {subdataset!r}, found {len(matches)}"
+        )
+        raise ValueError(msg)
+    return subdataset[: matches[0].end()]
+
+
+def _read_center_frequency(filename: PathOrStr, frequency_group_path: str) -> float:
+    """Read and validate the center frequency (in Hz) of one frequency group.
+
+    Parameters
+    ----------
+    filename : PathOrStr
+        Path or URL of the NISAR GSLC HDF5 file.
+    frequency_group_path : str
+        HDF5 path of the frequency group,
+        e.g. ``/science/LSAR/GSLC/grids/frequencyA``.
+
+    Returns
+    -------
+    float
+        Center frequency in Hz.
+
+    """
+    dataset_path = f"{frequency_group_path}/{CENTER_FREQUENCY_DATASET}"
+    err_prefix = (
+        f"Invalid {CENTER_FREQUENCY_DATASET} at {dataset_path!r} in {str(filename)!r}"
+    )
+
+    with open_h5(str(filename)) as hf:
+        if dataset_path not in hf:
+            msg = f"{err_prefix}: dataset not found"
+            raise ValueError(msg)
+        dset = hf[dataset_path]
+        # A group named `centerFrequency` has no shape and fails here too
+        if getattr(dset, "shape", None) != ():
+            msg = f"{err_prefix}: expected a scalar dataset"
+            raise ValueError(msg)
+        if not (
+            np.issubdtype(dset.dtype, np.floating)
+            or np.issubdtype(dset.dtype, np.integer)
+        ):
+            msg = f"{err_prefix}: expected a real-valued dtype, got {dset.dtype}"
+            raise ValueError(msg)
+        center_frequency = float(dset[()])
+
+    if not np.isfinite(center_frequency) or center_frequency <= 0:
+        msg = f"{err_prefix}: expected a positive, finite value, got {center_frequency}"
+        raise ValueError(msg)
+    return center_frequency

--- a/tests/test_nisar_wavelength.py
+++ b/tests/test_nisar_wavelength.py
@@ -1,0 +1,204 @@
+"""Tests for opera_utils.nisar._wavelength module."""
+
+from __future__ import annotations
+
+import re
+
+import h5py
+import numpy as np
+import pytest
+
+from opera_utils.constants import SPEED_OF_LIGHT
+from opera_utils.nisar import GslcProduct, get_nisar_wavelength
+
+# Example filename from the NISAR naming convention (see constants.py)
+GSLC_FILENAME = "NISAR_L2_PR_GSLC_004_076_A_022_2005_QPDH_A_20251103T110514_20251103T110549_X05007_N_F_J_001.h5"
+
+# NISAR L-band center frequencies (Hz) for the 20 MHz (A) and 5 MHz (B) modes
+FREQ_A = 1_257_500_000.0
+FREQ_B = 1_293_500_000.0
+FREQ_S = 3_200_000_000.0
+
+LSAR_GRIDS = "/science/LSAR/GSLC/grids"
+SSAR_GRIDS = "/science/SSAR/GSLC/grids"
+
+# Sentinel: create a *group* named centerFrequency instead of a dataset
+CENTER_FREQUENCY_AS_GROUP = object()
+
+
+@pytest.fixture
+def make_gslc(tmp_path):
+    """Return a factory creating a minimal GSLC HDF5 file.
+
+    The factory takes a mapping of frequency-group path to the value stored in
+    that group's ``centerFrequency`` dataset. A value of ``None`` creates the
+    group without a ``centerFrequency``; `CENTER_FREQUENCY_AS_GROUP` creates a
+    subgroup named ``centerFrequency`` instead of a dataset.
+    """
+
+    def _make(center_frequencies, image_datasets=(), filename=GSLC_FILENAME):
+        path = tmp_path / filename
+        with h5py.File(path, "w") as hf:
+            for group_path, value in center_frequencies.items():
+                group = hf.require_group(group_path)
+                if value is CENTER_FREQUENCY_AS_GROUP:
+                    group.create_group("centerFrequency")
+                elif value is not None:
+                    group.create_dataset("centerFrequency", data=value)
+            for dataset_path in image_datasets:
+                hf.create_dataset(
+                    dataset_path, data=np.zeros((2, 2), dtype=np.complex64)
+                )
+        return path
+
+    return _make
+
+
+@pytest.fixture
+def gslc_h5(make_gslc):
+    """A GSLC file with LSAR frequencyA/frequencyB groups and image data."""
+    return make_gslc(
+        {
+            f"{LSAR_GRIDS}/frequencyA": FREQ_A,
+            f"{LSAR_GRIDS}/frequencyB": FREQ_B,
+        },
+        image_datasets=[
+            f"{LSAR_GRIDS}/frequencyA/HH",
+            f"{LSAR_GRIDS}/frequencyB/VV",
+        ],
+    )
+
+
+class TestSubdatasetPathResolution:
+    @pytest.mark.parametrize(
+        ("subdataset", "center_frequency"),
+        [
+            (f"{LSAR_GRIDS}/frequencyA/HH", FREQ_A),
+            (f"{LSAR_GRIDS}/frequencyB/VV", FREQ_B),
+            (f"{LSAR_GRIDS}/frequencyB", FREQ_B),
+        ],
+        ids=["frequencyA-dataset", "frequencyB-dataset", "frequency-group-itself"],
+    )
+    def test_resolves_parent_frequency_group(
+        self, gslc_h5, subdataset, center_frequency
+    ):
+        wavelength = get_nisar_wavelength(gslc_h5, subdataset)
+        assert wavelength == pytest.approx(SPEED_OF_LIGHT / center_frequency)
+
+    def test_band_agnostic_ssar_path(self, make_gslc):
+        h5path = make_gslc({f"{SSAR_GRIDS}/frequencyA": FREQ_S})
+        wavelength = get_nisar_wavelength(h5path, f"{SSAR_GRIDS}/frequencyA")
+        assert wavelength == pytest.approx(SPEED_OF_LIGHT / FREQ_S)
+
+    def test_reads_from_subdataset_group_not_first_match(self, make_gslc):
+        # Both groups exist; the wavelength must come from the group containing
+        # the subdataset, not from whichever frequency group appears first
+        h5path = make_gslc(
+            {
+                f"{LSAR_GRIDS}/frequencyA": FREQ_A,
+                f"{LSAR_GRIDS}/frequencyB": FREQ_B,
+            }
+        )
+        wavelength = get_nisar_wavelength(h5path, f"{LSAR_GRIDS}/frequencyB/HH")
+        assert wavelength == pytest.approx(SPEED_OF_LIGHT / FREQ_B)
+
+    @pytest.mark.parametrize(
+        ("subdataset", "num_found"),
+        [
+            (f"{LSAR_GRIDS}/HH", 0),
+            (f"{LSAR_GRIDS}/frequencyC/HH", 0),
+            ("/x/frequencyAB/HH", 0),
+            ("/x/frequencyA/frequencyB/HH", 2),
+        ],
+        ids=[
+            "no-frequency-segment",
+            "frequencyC",
+            "substring-frequencyAB",
+            "two-frequency-segments",
+        ],
+    )
+    def test_invalid_subdataset_paths(self, gslc_h5, subdataset, num_found):
+        match = re.escape(repr(subdataset)) + f".*found {num_found}"
+        with pytest.raises(ValueError, match=match):
+            get_nisar_wavelength(gslc_h5, subdataset)
+
+
+class TestCenterFrequencyValidation:
+    FREQ_A_GROUP = f"{LSAR_GRIDS}/frequencyA"
+
+    def test_accepts_positive_integer_dtype(self, make_gslc):
+        h5path = make_gslc({self.FREQ_A_GROUP: np.int64(1_257_500_000)})
+        wavelength = get_nisar_wavelength(h5path, self.FREQ_A_GROUP)
+        assert wavelength == pytest.approx(SPEED_OF_LIGHT / FREQ_A)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            CENTER_FREQUENCY_AS_GROUP,
+            np.array([FREQ_A, FREQ_B]),
+            np.complex64(FREQ_A),
+            True,
+            "1257500000",
+            -1.0,
+            0.0,
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+        ],
+        ids=[
+            "missing",
+            "group-not-dataset",
+            "non-scalar",
+            "complex-dtype",
+            "bool-dtype",
+            "string-dtype",
+            "negative",
+            "zero",
+            "nan",
+            "positive-inf",
+            "negative-inf",
+        ],
+    )
+    def test_rejects_invalid_center_frequency(self, make_gslc, value):
+        h5path = make_gslc({self.FREQ_A_GROUP: value})
+        with pytest.raises(ValueError, match="centerFrequency"):
+            get_nisar_wavelength(h5path, self.FREQ_A_GROUP)
+
+    def test_error_message_includes_filename_and_dataset_path(self, make_gslc):
+        h5path = make_gslc({self.FREQ_A_GROUP: None})
+        with pytest.raises(ValueError, match="dataset not found") as excinfo:
+            get_nisar_wavelength(h5path, self.FREQ_A_GROUP)
+        message = str(excinfo.value)
+        assert str(h5path) in message
+        assert f"{self.FREQ_A_GROUP}/centerFrequency" in message
+
+
+class TestKnownWavelengths:
+    def test_nisar_l_band_wavelength(self, gslc_h5):
+        wavelength = get_nisar_wavelength(gslc_h5, f"{LSAR_GRIDS}/frequencyA/HH")
+        assert wavelength == pytest.approx(SPEED_OF_LIGHT / 1_257_500_000.0)
+        # Independent literal check: NISAR L-band 20 MHz mode is ~23.84 cm
+        assert wavelength == pytest.approx(0.23840, rel=1e-4)
+
+
+class TestGslcProductGetWavelength:
+    def test_default_frequency_a(self, gslc_h5):
+        product = GslcProduct.from_filename(gslc_h5)
+        assert product.get_wavelength() == pytest.approx(SPEED_OF_LIGHT / FREQ_A)
+
+    def test_frequency_b(self, gslc_h5):
+        product = GslcProduct.from_filename(gslc_h5)
+        assert product.get_wavelength("B") == pytest.approx(SPEED_OF_LIGHT / FREQ_B)
+
+    def test_invalid_frequency(self, gslc_h5):
+        product = GslcProduct.from_filename(gslc_h5)
+        with pytest.raises(ValueError, match="Invalid frequency"):
+            product.get_wavelength("C")
+
+    def test_frequency_b_only_product(self, make_gslc):
+        h5path = make_gslc({f"{LSAR_GRIDS}/frequencyB": FREQ_B})
+        product = GslcProduct.from_filename(h5path)
+        assert product.get_wavelength("B") == pytest.approx(SPEED_OF_LIGHT / FREQ_B)
+        with pytest.raises(ValueError, match="dataset not found"):
+            product.get_wavelength()


### PR DESCRIPTION
## Summary

NISAR GSLC products state their radar center frequency per frequency sub-band, in `centerFrequency`, but `opera_utils` has no reader for it. 
This adds one:

- `opera_utils.nisar.get_nisar_wavelength(filename, subdataset)` — resolves the frequency group from the `subdataset` path and returns `SPEED_OF_LIGHT / centerFrequency`.
- `GslcProduct.get_wavelength(frequency="A")` — a thin convenience wrapper for when you have a product object rather than a subdataset path.

Both work on local files and remote (HTTPS/S3) URLs through `open_h5`. This is a pure addition: no existing function or signature changes.

## Motivation

Downstream, dolphin cannot auto-detect the radar wavelength for NISAR GSLC inputs ([isce-framework/dolphin#704][issue]); its wavelength stays unset and `timeseries/` outputs silently remain in radians. In that issue, the suggestion was to put the metadata reader in `opera_utils` rather than in dolphin, since this is exactly the kind of product-metadata access `opera_utils.nisar` already owns. 
This PR is that reader.

A tempting shortcut is a hardcoded L-band constant (or a mode→frequency lookup table keyed on the filename). Real products rule that out. Across the `NISAR_L2_GSLC_BETA_V1` collection we measured **six distinct** center frequencies — 1221.5, 1229.0, 1236.5, 1239.0, 1257.5, 1293.5 MHz — a wavelength spread of ~13.7 mm (5.9% of a wavelength). No single constant is correct, and many granules carry **both** `frequencyA` and `frequencyB` with two different center frequencies in one file, so the filename alone cannot say which applies.
The product states the value exactly; the right move is to read it.

[issue]: https://github.com/isce-framework/dolphin/issues/704

## Design

- **The frequency group is located from the `subdataset` path**, not guessed.
  Reading the subdataset `.../frequencyA/HH` reads `.../frequencyA/centerFrequency` from the same group. This makes the wavelength always match the radar band and sub-band of the data actually being processed, and it removes any LSAR/SSAR
  ambiguity structurally (the band is part of the path).
- **Never falls back to another sub-band.** The core reader never guesses: its sub-band comes from the `subdataset` path (exactly one `frequencyA`/`frequencyB` segment required). The convenience method follows the existing `GslcProduct`
  convention of defaulting its `frequency` argument to `"A"`, but it never falls back to another *available* sub-band — on a frequencyB-only product, omitting the argument raises rather than silently returning B. This matters because A and B can differ by ~2.8% in wavelength, and that error would propagate directly into displacement.
- **Fail loud, with context.** Missing or invalid `centerFrequency` (non-scalar, non-real dtype, non-finite, ≤ 0) raises a `ValueError` naming the dataset path and the file, rather than returning a plausible-but-wrong number.

## Testing

- **Unit tests** (`tests/test_nisar_wavelength.py`, 27 tests): synthetic GSLC HDF5 built with `h5py`, covering subdataset path resolution (frequencyA/B, the group itself, SSAR paths, reading the subdataset's own group rather than the
  first frequency group), path validation (missing/multiple frequency segments, `frequencyC`, `frequencyAB`), `centerFrequency` validation (positive integer dtype accepted; missing, group-instead-of-dataset, non-scalar, complex/bool/ string dtypes, zero, negative, NaN, ±inf rejected with filename + path in the message), a known-value check (a 1,257.5 MHz center frequency ≈ 23.84 cm), and the `GslcProduct` delegation including a frequencyB-only product where the default `"A"` correctly raises.
- **Real-data validation**: run against 13 real GSLC granules (one per
  (mode, polarization) configuration) via remote byte-range reads — no bulk download. All 22 present sub-bands returned exactly `c / centerFrequency` (bit-identical), all 4 absent sub-bands raised as designed, and the product  method matched. Reproducible with `make validate-wavelength`; the full report (pinned) is [here][report], and the harness lives in the same repository.

[report]: https://github.com/s-sasaki-earthsea-wizard/dolphin-nisar-sample/blob/3e3d025958448ff8ce646338426973666d64d1a6/reports/wavelength_validation.md

## API policy question

Currently the reader raises `ValueError` in two distinct situations: (a) the requested sub-band is genuinely absent from the product, and (b) the sub-band is present but its `centerFrequency` metadata is invalid. Case (b) — present but
invalid — should always raise, and I am not proposing to change it.

The one open choice is case (a): would maintainers prefer `get_nisar_wavelength` / `get_wavelength` to return `None` for a genuinely absent requested sub-band, so the caller decides what to do? 
The current raise-on-absent keeps a `float`-only return type and surfaces product/request mismatches loudly; returning `None` would change the public contract to `float | None`. 
Happy to go either way — flagging it here since it is the one user-visible policy decision in the PR.

## Disclosure

These features, investigations, and tests were developed with AI assistance — Claude Opus 4.8 and Fable 5 (Anthropic), and GPT-5.6 Terra (OpenAI). All code was reviewed by the author and validated against an actual NISAR sample product.*