### PR TITLE
Shadow `osr` import behind `HAS_GDAL` check for `_cslc.py`

### DIFF
--- a/src/opera_utils/_cslc.py
+++ b/src/opera_utils/_cslc.py
@@ -12,7 +12,6 @@ from typing import Any, Callable
 
 import h5py
 import numpy as np
-from osgeo import osr
 from pyproj import CRS, Transformer
 from shapely import geometry, ops, wkt
 
@@ -30,6 +29,7 @@ try:
 except ImportError:
     HAS_GDAL = False
     gdal = None
+    osr = None
 
 from ._types import Filename
 from .bursts import normalize_burst_id

--- a/src/opera_utils/_cslc.py
+++ b/src/opera_utils/_cslc.py
@@ -23,7 +23,7 @@ except ImportError:
     HAS_ICE3 = False
 
 try:
-    from osgeo import gdal
+    from osgeo import gdal, osr
 
     HAS_GDAL = True
 except ImportError:


### PR DESCRIPTION
Since some helpers (like download/search/subset) do not need gdal, we had this as an optional dependency which let people do things like `uvx opera-utils ...` on the fly using PyPi